### PR TITLE
Fixed problem where negative float data was not mapped.

### DIFF
--- a/lib/MaRC/Image.h
+++ b/lib/MaRC/Image.h
@@ -15,10 +15,8 @@
 #include <MaRC/NaN.h>
 
 #include <limits>
+#include <cassert>
 
-#ifdef DEBUG
-# include <cassert>
-#endif  /* DEBUG */
 
 namespace MaRC
 {
@@ -43,7 +41,6 @@ namespace MaRC
       for (T * image = begin; image != end; ++image)
         *image = T ();
     }
-
   };
 
   // Image_traits specializations.
@@ -56,20 +53,6 @@ namespace MaRC
       for (float * image = begin; image != end; ++image)
         *image = static_cast<float> (MaRC::NaN);
     }
-
-    static float minimum (double min)
-    {
-      static const float absolute_min =
-        -std::numeric_limits<float>::min () - 1;
-      return (min < absolute_min ? absolute_min : min);
-    }
-
-    static float maximum (double max)
-    {
-      static const float absolute_max = std::numeric_limits<float>::max ();
-      return (max > absolute_max ? absolute_max : max);
-    }
-
   };
 
   template <>
@@ -81,7 +64,6 @@ namespace MaRC
       for (double * image = begin; image != end; ++image)
         *image = static_cast<double> (MaRC::NaN);
     }
-
   };
 
 

--- a/lib/MaRC/MapFactory.h
+++ b/lib/MaRC/MapFactory.h
@@ -76,8 +76,8 @@ namespace MaRC
         const SourceImage & source,
         unsigned int samples,
         unsigned int lines,
-        double minimum = -std::numeric_limits<double>::max (),
-        double maximum =  std::numeric_limits<double>::max ()) = 0;
+        double minimum = std::numeric_limits<double>::lowest(),
+        double maximum = std::numeric_limits<double>::max()) = 0;
 
     /// Create the latitude/longitude grid for the desired map
     /// projection.

--- a/lib/MaRC/Map_traits.h
+++ b/lib/MaRC/Map_traits.h
@@ -51,8 +51,8 @@ namespace MaRC
      */
     static T minimum (double min)
     {
-      static const T absolute_min = std::numeric_limits<T>::min ();
-      return (min < absolute_min ? absolute_min : static_cast<T> (min));
+      static constexpr T absolute_min = std::numeric_limits<T>::lowest();
+      return (min < absolute_min ? absolute_min : static_cast<T>(min));
     }
 
     /// Make sure given maximum value falls within map data type
@@ -73,8 +73,8 @@ namespace MaRC
      */
     static T maximum (double max)
     {
-      static const T absolute_max = std::numeric_limits<T>::max ();
-      return (max > absolute_max ? absolute_max : static_cast<T> (max));
+      static constexpr T absolute_max = std::numeric_limits<T>::max();
+      return (max > absolute_max ? absolute_max : static_cast<T>(max));
     }
 
   };
@@ -85,14 +85,20 @@ namespace MaRC
   {
     static float minimum (double min)
     {
-      static const float absolute_min =
-        -std::numeric_limits<float>::min () - 1;
+      /**
+       * @todo Why do we need to add one here?  Why not just drop this
+       *       @c float specialization entirely.  The generalized
+       *       trait above appears to be sufficient.
+       */
+      static constexpr float absolute_min =
+        std::numeric_limits<float>::lowest() + 1;
       return (min < absolute_min ? absolute_min : min);
     }
 
     static float maximum (double max)
     {
-      static const float absolute_max = std::numeric_limits<float>::max ();
+      static constexpr float absolute_max =
+          std::numeric_limits<float>::max();
       return (max > absolute_max ? absolute_max : max);
     }
 

--- a/src/ImageFactory.cpp
+++ b/src/ImageFactory.cpp
@@ -8,7 +8,7 @@ MaRC::ImageFactory::~ImageFactory (void)
 }
 
 MaRC::ImageFactory::ImageFactory (void)
-  : minimum_ (-std::numeric_limits<double>::max ()),
-    maximum_ ( std::numeric_limits<double>::max ())
+  : minimum_(std::numeric_limits<double>::lowest())
+  , maximum_(std::numeric_limits<double>::max())
 {
 }

--- a/src/parse_scan.cpp
+++ b/src/parse_scan.cpp
@@ -7,17 +7,17 @@
 
 
 MaRC::ParseParameter::ParseParameter (void)
-  : lat_interval (10),
-    lon_interval (10),
-    minimum (-std::numeric_limits<double>::max ()),
-    maximum (std::numeric_limits<double>::max ()),
-    nibble_left   (0),
-    nibble_right  (0),
-    nibble_top    (0),
-    nibble_bottom (0),
-    commands_ (),
-    sym_table_ ()// ,
-//     lexer_ ()
+  : lat_interval(10)
+  , lon_interval(10)
+  , minimum(std::numeric_limits<decltype(this->minimum)>::lowest())
+  , maximum(std::numeric_limits<decltype(this->maximum)>::max())
+  , nibble_left  (0)
+  , nibble_right (0)
+  , nibble_top   (0)
+  , nibble_bottom(0)
+  , commands_()
+  , sym_table_()
+  // , lexer_()
 {
 }
 


### PR DESCRIPTION
Float typed data less than -1 would not be mapped due to a bug in the
data clipping implementation for the float data type.  MaRC depended
on -std::numeric_limits<float>::max() - 1 to determine the minimum
(lowest) mappable value of type float.  However, the
MaRC::Map_traits<float>::minimum() specialization incorrectly used
std::numeric_limits<>::min() instead of max().  The
numeric_limits<>::min() trait provides the *smallest* representable
value for floating point types, which is not the same as the lowest.
The lowest is the negative of max().  This differs from
numeric_limits<>::min() for integer types.  To reduce confusion,
consistently use the C++11 std::numeric_limits<>::lowest() trait
throughout MaRC instead since it provides the desired behavior without
having to if the type is an integer or a floating point.  (Fixes #2)