### PR TITLE
Added support for 64 bit integer map data types.

### DIFF
--- a/doc/MaRC_input.texi
+++ b/doc/MaRC_input.texi
@@ -445,6 +445,7 @@ types are:
 @cindex @code{BYTE}
 @cindex @code{SHORT}
 @cindex @code{LONG}
+@cindex @code{LONGLONG}
 @cindex @code{FLOAT}
 @cindex @code{DOUBLE}
 
@@ -458,6 +459,9 @@ types are:
 
 @item LONG
 4 byte (32 bits) signed integer
+
+@item LONGLONG
+8 byte (64 bits) signed integer
 
 @item FLOAT
 4 byte (32 bits) floating point number

--- a/src/FITS_traits.h
+++ b/src/FITS_traits.h
@@ -107,6 +107,14 @@ namespace MaRC
         };
 
         template <>
+        struct traits<longlong_type>
+        {
+            static constexpr int  bitpix                 = LONGLONG_IMG;
+            static constexpr int  datatype               = TLONGLONG;
+            static constexpr bool supports_blank_keyword = true;
+        };
+
+        template <>
         struct traits<float>
         {
             static constexpr int  bitpix                 = FLOAT_IMG;

--- a/src/lexer.ll
+++ b/src/lexer.ll
@@ -36,7 +36,7 @@ int yycolumn = 1;
         yylloc->last_line = yylineno;                \
         yylloc->first_column = yycolumn;             \
         yylloc->last_column = yycolumn + yyleng - 1; \
- 	yycolumn += yyleng; }
+        yycolumn += yyleng; }
 %}
 
 %option noyywrap
@@ -52,58 +52,58 @@ int yycolumn = 1;
 %s pole
 
 %%
-<comment_init>[:]	{
-			  BEGIN(comment); return ':';
-			  /* This colon is seperated from <comment> so
-			     colons may be placed in side of comments */
-			}
-<comment>[^\n]*		{
+<comment_init>[:]       {
+                          BEGIN(comment); return ':';
+                          /* This colon is seperated from <comment> so
+                             colons may be placed in side of comments */
+                        }
+<comment>[^\n]*         {
   BEGIN(INITIAL); yylval->sval = strdup (yytext); return _STRING;
   /* Comments must end with a carriage return */
-			}
-<keyword_token>[:]	{ BEGIN(INITIAL); return ':'; }
+                        }
+<keyword_token>[:]      { BEGIN(INITIAL); return ':'; }
 <string>{
-	[:]		return ':';
-	[[:graph:]]+	BEGIN(INITIAL); yylval->sval = strdup (yytext) ;return _STRING;
+        [:]             return ':';
+        [[:graph:]]+    BEGIN(INITIAL); yylval->sval = strdup (yytext) ;return _STRING;
 }
 <pole>{
         [:]             return ':';
-	N               BEGIN(INITIAL); return 'N';
-	"NORTH"         BEGIN(INITIAL); return 'N';
-	S               BEGIN(INITIAL); return 'S';
-	"SOUTH"         BEGIN(INITIAL); return 'S';
+        N               BEGIN(INITIAL); return 'N';
+        "NORTH"         BEGIN(INITIAL); return 'N';
+        S               BEGIN(INITIAL); return 'S';
+        "SOUTH"         BEGIN(INITIAL); return 'S';
 }
 
-[:]			{ BEGIN(expression); return ':'; }
+[:]                     { BEGIN(expression); return ':'; }
 <expression>{
-	#[^\n]*		/* eat up one line text comments in MaRC input file */
-	[ \t]+		/* eat up whitespace except for carriage return */
-	"AUTO"                          { BEGIN(INITIAL); return AUTO; }
-	"TABLE"                         { BEGIN(INITIAL); return TABLE; }
-	\=				{ return '='; }
-	\+				{ return '+'; }
-	\-				{ return '-'; }
-	\*				{ return '*'; }
-	\/				{ return '/'; }
-	\^				{ return '^'; }
-	\(				{ return '('; }
-	\)				{ return ')'; }
-	C				{ return 'C'; }
-	G				{ return 'G'; }
-	N				{ return 'N'; }
-	S				{ return 'S'; }
-	E				{ return 'E'; }
-	W				{ return 'W'; }
-	"AU"				{ return AU;  }
-	"KM"				{ return KM;  }
-	"CW"                            { return CW;  }
-	"CCW"                           { return CCW; }
+        #[^\n]*         /* eat up one line text comments in MaRC input file */
+        [ \t]+          /* eat up whitespace except for carriage return */
+        "AUTO"                          { BEGIN(INITIAL); return AUTO; }
+        "TABLE"                         { BEGIN(INITIAL); return TABLE; }
+        \=                              { return '='; }
+        \+                              { return '+'; }
+        \-                              { return '-'; }
+        \*                              { return '*'; }
+        \/                              { return '/'; }
+        \^                              { return '^'; }
+        \(                              { return '('; }
+        \)                              { return ')'; }
+        C                               { return 'C'; }
+        G                               { return 'G'; }
+        N                               { return 'N'; }
+        S                               { return 'S'; }
+        E                               { return 'E'; }
+        W                               { return 'W'; }
+        "AU"                            { return AU;  }
+        "KM"                            { return KM;  }
+        "CW"                            { return CW;  }
+        "CCW"                           { return CCW; }
         [[:digit:]]*("."[[:digit:]]*)?(E[-+]?[[:digit:]]{1,3})?          {
             // Numbers will be handled in double precision
           yylval->val = strtod (yytext, 0);
             return NUM;
           }
-	[[:alpha:]]+[[:digit:]]*          {
+        [[:alpha:]]+[[:digit:]]*          {
             MaRC::sym_entry * const s = pp.sym_table ().getsym (yytext);
 
             if (s == 0)
@@ -126,76 +126,76 @@ int yycolumn = 1;
 
             return s->type;  // This returns either FNCT or VAR.
           }
-	.               {
-	                        BEGIN(INITIAL); return UNMATCHED;
-				/* any character (byte) except newline */
-	                }
-	\n		{
-				BEGIN(INITIAL);
-				/* Mathematical expressions
+        .               {
+                                BEGIN(INITIAL); return UNMATCHED;
+                                /* any character (byte) except newline */
+                        }
+        \n              {
+                                BEGIN(INITIAL);
+                                /* Mathematical expressions
                                    must end with a carriage return */
-			}
+                        }
 }
 
-"ALBEQV1"	{ return _ALBEQV1; }
-"ALBEQV2"	{ return _ALBEQV2; }
+"ALBEQV1"       { return _ALBEQV1; }
+"ALBEQV2"       { return _ALBEQV2; }
 "IDENTITY"      { return _IDENTITY; }
-"LAMCNF1"	{ return _LAMCNF1; }
-"LAMCNF2"	{ return _LAMCNF2; }
-"LAMCYLEQ"	{ return _LAMCYLEQ; }
-"LAMPOLEQ"	{ return _LAMPOLEQ; }
-"MERCATOR"	{ return _MERCATOR; }
-"ORTHO"		{ return _ORTHO; }
-"P_STEREO"	{ return _P_STEREO; }
+"LAMCNF1"       { return _LAMCNF1; }
+"LAMCNF2"       { return _LAMCNF2; }
+"LAMCYLEQ"      { return _LAMCYLEQ; }
+"LAMPOLEQ"      { return _LAMPOLEQ; }
+"MERCATOR"      { return _MERCATOR; }
+"ORTHO"         { return _ORTHO; }
+"P_STEREO"      { return _P_STEREO; }
 "PERSPECTIVE"   { return _PERSPECTIVE; }
-"SIMPLE_C"	{ return _SIMPLE_C; }
-"SINUSOID"	{ return _SINUSOID; }
+"SIMPLE_C"      { return _SIMPLE_C; }
+"SINUSOID"      { return _SINUSOID; }
 
-"MAP"		{ BEGIN(string); return _MAP; }
+"MAP"           { BEGIN(string); return _MAP; }
 "AUTHOR"        { BEGIN(comment_init); return AUTHOR; }
 "ORIGIN"        { BEGIN(comment_init); return ORIGIN; }
-"COMMENT"	{ BEGIN(comment_init); return _COMMENT; }
-"XCOMMENT"	{ BEGIN(comment_init); return XCOMMENT; }
-"DATA_OFFSET"	{ return DATA_OFFSET; }
-"DATA_SCALE"	{ return DATA_SCALE; }
-"DATA_TYPE"	{ BEGIN(keyword_token);  return _DATA_TYPE; }
+"COMMENT"       { BEGIN(comment_init); return _COMMENT; }
+"XCOMMENT"      { BEGIN(comment_init); return XCOMMENT; }
+"DATA_OFFSET"   { return DATA_OFFSET; }
+"DATA_SCALE"    { return DATA_SCALE; }
+"DATA_TYPE"     { BEGIN(keyword_token);  return _DATA_TYPE; }
 "DATA_BLANK"    { return DATA_BLANK; }
-"GRID"		{ BEGIN(keyword_token); return GRID; }
-"GRID_INTERVAL"	{ return GRID_INTERVAL; }
-"LAT_GRID_INTERVAL"	{ return LAT_GRID_INTERVAL; }
-"LON_GRID_INTERVAL"	{ return LON_GRID_INTERVAL; }
-"TYPE"		{ BEGIN(keyword_token); return MAP_TYPE; }
-"PROJECTION"	{ BEGIN(keyword_token); return MAP_TYPE; }
-"SAMPLES"	{ return SAMPLES; }
-"LINES"		{ return LINES; }
-"BODY"		{ BEGIN(string); return BODY; }
+"GRID"          { BEGIN(keyword_token); return GRID; }
+"GRID_INTERVAL" { return GRID_INTERVAL; }
+"LAT_GRID_INTERVAL"     { return LAT_GRID_INTERVAL; }
+"LON_GRID_INTERVAL"     { return LON_GRID_INTERVAL; }
+"TYPE"          { BEGIN(keyword_token); return MAP_TYPE; }
+"PROJECTION"    { BEGIN(keyword_token); return MAP_TYPE; }
+"SAMPLES"       { return SAMPLES; }
+"LINES"         { return LINES; }
+"BODY"          { BEGIN(string); return BODY; }
 "AVERAGING"     { BEGIN(keyword_token); return AVERAGING; }
 "NONE"          { return NONE; }
 "WEIGHTED"      { return WEIGHTED; }
 "UNWEIGHTED"    { return UNWEIGHTED; }
-"PLANES"	{ return PLANES; }
-"PROGRADE"	{ return PROGRADE; }
-"RETROGRADE"	{ return RETROGRADE; }
-"FLATTENING"	{ return FLATTENING; }
-"OPTIONS"	{ BEGIN(keyword_token);  return OPTIONS; }
-"EQ_RAD"	{ return EQ_RAD; }
-"POL_RAD"	{ return POL_RAD; }
-"ROTATION"	{ BEGIN(keyword_token); return ROTATION; }
-"IMAGE"		{ BEGIN(string); return _IMAGE; }
-"PHOTO"		{ return _PHOTO; }
-"MU"		{ BEGIN(keyword_token); return _MU; }
-"MU0"		{ BEGIN(keyword_token); return _MU0; }
-"PHASE"		{ BEGIN(keyword_token); return _PHASE; }
-"PLANE"		{ return PLANE; }
-"DATA_MIN"	{ return DATA_MIN; }
-"DATA_MAX"	{ return DATA_MAX; }
-"LO_LAT"	{ return LO_LAT; }
-"HI_LAT"	{ return HI_LAT; }
-"LO_LON"	{ return LO_LON; }
-"HI_LON"	{ return HI_LON; }
+"PLANES"        { return PLANES; }
+"PROGRADE"      { return PROGRADE; }
+"RETROGRADE"    { return RETROGRADE; }
+"FLATTENING"    { return FLATTENING; }
+"OPTIONS"       { BEGIN(keyword_token);  return OPTIONS; }
+"EQ_RAD"        { return EQ_RAD; }
+"POL_RAD"       { return POL_RAD; }
+"ROTATION"      { BEGIN(keyword_token); return ROTATION; }
+"IMAGE"         { BEGIN(string); return _IMAGE; }
+"PHOTO"         { return _PHOTO; }
+"MU"            { BEGIN(keyword_token); return _MU; }
+"MU0"           { BEGIN(keyword_token); return _MU0; }
+"PHASE"         { BEGIN(keyword_token); return _PHASE; }
+"PLANE"         { return PLANE; }
+"DATA_MIN"      { return DATA_MIN; }
+"DATA_MAX"      { return DATA_MAX; }
+"LO_LAT"        { return LO_LAT; }
+"HI_LAT"        { return HI_LAT; }
+"LO_LON"        { return LO_LON; }
+"HI_LON"        { return HI_LON; }
 "LATITUDE_TYPE" { BEGIN(keyword_token); return LATITUDE_TYPE; }
-"CENTRIC_LAT"|"CENTRIC"	{ return CENTRIC; }
-"GRAPHIC_LAT"|"GRAPHIC"	{ return GRAPHIC; }
+"CENTRIC_LAT"|"CENTRIC" { return CENTRIC; }
+"GRAPHIC_LAT"|"GRAPHIC" { return GRAPHIC; }
 "LATITUDE"      { BEGIN(keyword_token); return LATITUDE; }
 "LONGITUDE"     { return LONGITUDE; }
 "POLE"          { BEGIN(pole); return POLE; }
@@ -203,47 +203,48 @@ int yycolumn = 1;
 "STD_LAT"       { return STD_LAT; }
 "STD_LAT_1"     { return STD_LAT_1; }
 "STD_LAT_2"     { return STD_LAT_2; }
-"INTERPOLATE"	{ BEGIN(keyword_token); return _INTERPOLATE; }
+"INTERPOLATE"   { BEGIN(keyword_token); return _INTERPOLATE; }
 "REMOVE_SKY"    { BEGIN(keyword_token); return _REMOVE_SKY; }
-"NIBBLE"	{ return NIBBLE; }
-"NIBBLE_LEFT"	{ return NIBBLE_LEFT; }
-"NIBBLE_RIGHT"	{ return NIBBLE_RIGHT; }
-"NIBBLE_TOP"	{ return NIBBLE_TOP; }
-"NIBBLE_BOTTOM"	{ return NIBBLE_BOTTOM; }
+"NIBBLE"        { return NIBBLE; }
+"NIBBLE_LEFT"   { return NIBBLE_LEFT; }
+"NIBBLE_RIGHT"  { return NIBBLE_RIGHT; }
+"NIBBLE_TOP"    { return NIBBLE_TOP; }
+"NIBBLE_BOTTOM" { return NIBBLE_BOTTOM; }
 "INVERT"        { BEGIN(keyword_token); return INVERT; }
 "VERTICAL"      { return VERTICAL; }
 "HORIZONTAL"    { return HORIZONTAL; }
 "BOTH"          { return BOTH; }
-"SAMPLE_CENTER"	{ return SAMPLE_CENTER; }
-"LINE_CENTER"	{ return LINE_CENTER; }
-"LAT_AT_CENTER"	{ return LAT_AT_CENTER; }
-"LON_AT_CENTER"	{ return LON_AT_CENTER; }
+"SAMPLE_CENTER" { return SAMPLE_CENTER; }
+"LINE_CENTER"   { return LINE_CENTER; }
+"LAT_AT_CENTER" { return LAT_AT_CENTER; }
+"LON_AT_CENTER" { return LON_AT_CENTER; }
 "SAMPLE_OA"     { return SAMPLE_OA; }
 "LINE_OA"       { return LINE_OA; }
-"FLAT_FIELD"	{ BEGIN(string); return FLAT_FIELD; }
+"FLAT_FIELD"    { BEGIN(string); return FLAT_FIELD; }
 "MINNAERT"      { return MINNAERT; }
 "AUTO"          { return AUTO; }
 "TABLE"         { return TABLE; }
-"GEOM_CORRECT"	{ BEGIN(keyword_token); return GEOM_CORRECT; }
+"GEOM_CORRECT"  { BEGIN(keyword_token); return GEOM_CORRECT; }
 "EMI_ANG_LIMIT" { return _EMI_ANG_LIMIT; }
 "TERMINATOR"    { BEGIN(keyword_token); return TERMINATOR; }
-"SUB_OBSERV_LAT"	{ return SUB_OBSERV_LAT; }
-"SUB_OBSERV_LON"	{ return SUB_OBSERV_LON; }
-"POSITION_ANGLE"	{ return POSITION_ANGLE; }
-"SUB_SOLAR_LAT"		{ return SUB_SOLAR_LAT; }
-"SUB_SOLAR_LON"		{ return SUB_SOLAR_LON; }
-"RANGE"		{ return RANGE; }
-"FOCAL_LENGTH"	{ return FOCAL_LENGTH; }
-"PIXEL_SCALE"	{ return PIXEL_SCALE; }
-"ARCSEC_PER_PIX"	{ return ARCSEC_PER_PIX; }
-"KM_PER_PIXEL"	{ return KM_PER_PIXEL; }
-"BYTE"		{ return BYTE_DATA; }
-"SHORT"		{  return SHORT_DATA; }
-"LONG"		{ return LONG_DATA; }
-"FLOAT"		{ return FLOAT_DATA; }
-"DOUBLE"	{ return DOUBLE_DATA; }
-"YES"|"Y"	{ return YES; }
-"NO"|"N"	{ return NO; }
-#[^\n]*		/* eat up one line text comments in MaRC input file */
-[ \t\n]+		/* eat up whitespace */
-<*>.		{ return UNMATCHED; }
+"SUB_OBSERV_LAT"        { return SUB_OBSERV_LAT; }
+"SUB_OBSERV_LON"        { return SUB_OBSERV_LON; }
+"POSITION_ANGLE"        { return POSITION_ANGLE; }
+"SUB_SOLAR_LAT"         { return SUB_SOLAR_LAT; }
+"SUB_SOLAR_LON"         { return SUB_SOLAR_LON; }
+"RANGE"         { return RANGE; }
+"FOCAL_LENGTH"  { return FOCAL_LENGTH; }
+"PIXEL_SCALE"   { return PIXEL_SCALE; }
+"ARCSEC_PER_PIX"        { return ARCSEC_PER_PIX; }
+"KM_PER_PIXEL"  { return KM_PER_PIXEL; }
+"BYTE"          { return BYTE_DATA; }
+"SHORT"         {  return SHORT_DATA; }
+"LONG"          { return LONG_DATA; }
+"LONGLONG"      { return LONGLONG_DATA; }
+"FLOAT"         { return FLOAT_DATA; }
+"DOUBLE"        { return DOUBLE_DATA; }
+"YES"|"Y"       { return YES; }
+"NO"|"N"        { return NO; }
+#[^\n]*         /* eat up one line text comments in MaRC input file */
+[ \t\n]+                /* eat up whitespace */
+<*>.            { return UNMATCHED; }

--- a/tests/test_map.inp
+++ b/tests/test_map.inp
@@ -7,7 +7,7 @@ XCOMMENT: Test FITS extension comment.
                 POL_RAD:        66854
                 ROTATION:       PROGRADE
 
-        DATA_TYPE:              LONG
+        DATA_TYPE:              LONGLONG
         GRID:                   YES
         GRID_INTERVAL:          2
         TYPE:                   SIMPLE_C


### PR DESCRIPTION
Maps with signed 64 bit integer data types may now be generated by
setting the DATA_TYPE to LONGLONG in the map MaRC input file.
(Closes #9)

See the following for details on support for 64 bit integers in FITS
files: https://fits.gsfc.nasa.gov/fits_64bit.html