### PR TITLE
Latitude/longitude visibility improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,9 @@ tests/Vector_Test.trs
 tests/Matrix_Test
 tests/Matrix_Test.log
 tests/Matrix_Test.trs
+tests/Geometry_Test
+tests/Geometry_Test.log
+tests/Geometry_Test.trs
 tests/OblateSpheroid_Test
 tests/OblateSpheroid_Test.log
 tests/OblateSpheroid_Test.trs

--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,9 @@ tests/Vector_Test.trs
 tests/Matrix_Test
 tests/Matrix_Test.log
 tests/Matrix_Test.trs
+tests/OblateSpheroid_Test
+tests/OblateSpheroid_Test.log
+tests/OblateSpheroid_Test.trs
 tests/test-suite.log
 tests/test_map.fits
 ylwrap

--- a/Doxyfile
+++ b/Doxyfile
@@ -855,7 +855,7 @@ RECURSIVE              = YES
 # Note that relative paths are relative to the directory from which doxygen is
 # run.
 
-EXCLUDE                = src/parse.{h,cc} src/lexer.cc
+EXCLUDE                = src/parse.{hh,cc} src/lexer.cc
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded

--- a/lib/MaRC/BodyData.h
+++ b/lib/MaRC/BodyData.h
@@ -36,6 +36,12 @@ namespace MaRC
      *
      * Concrete @c BodyData implementations must subclass this
      * abstract base class.
+     *
+     * @todo @c BodyData class methods that only have a latitude
+     *       should really have a longitude parameter as well.
+     *       Without a longitude parameter only bodies that are
+     *       symmetrical about their polar axis can be implemented as
+     *       subclasses.
      */
     class BodyData
     {

--- a/lib/MaRC/BodyData.h
+++ b/lib/MaRC/BodyData.h
@@ -61,27 +61,46 @@ namespace MaRC
          */
         bool prograde() const { return this->prograde_; }
 
-        /// Find radius as a function of centric latitude.
+        /// Find radius as a function of bodycentric latitude.
         /**
-         * @param[in] lat Bodycentric (e.g. planetocentric) latitude.
+         * Calculate and return the radius, i.e. distance from the
+         * center of the body to the point on the surface at given
+         * latitude.
          *
-         * @return Radius at given latitude.
+         * @param[in] lat Bodycentric (e.g. planetocentric) latitude
+         *                in radians.
+         *
+         * @return Radius, i.e. distance from the center of the body
+         *         to point on the surface at given latitude.
+         *
+         * @todo We really should add a longitude parameter since not
+         *       all bodies are symmetrical about their polar axis.
+         *
          */
         virtual double centric_radius(double lat) const = 0;
 
         /// Convert from GRAPHIC to CENTRIC latitude
         /**
-         * @param[in] lat graphic (e.g. planetographic) latitude
+         * @param[in] lat Graphic (e.g. planetographic) latitude in
+         *                radians.
          *
-         * @return Bodycentric latitude.
+         * @return Bodycentric latitude in radians.
+         *
+         * @todo We really should add a longitude parameter since not
+         *       all bodies are symmetrical about their polar axis.
+         *
          */
         virtual double centric_latitude(double lat) const = 0;
 
         /// Convert from CENTRIC to GRAPHIC latitude
         /**
-         * @param[in] lat centric (e.g. planetocentric) latitude
+         * @param[in] lat Centric (e.g. planetocentric) latitude in
+         *                radians.
          *
-         * @return Bodygraphic latitude.
+         * @return Bodygraphic latitude in radians.
+         *
+         * @todo We really should add a longitude parameter since not
+         *       all bodies are symmetrical about their polar axis.
          */
         virtual double graphic_latitude(double lat) const = 0;
 

--- a/lib/MaRC/CosPhaseImage.cpp
+++ b/lib/MaRC/CosPhaseImage.cpp
@@ -22,12 +22,11 @@
  */
 
 #include "CosPhaseImage.h"
-#include "MuImage.h"
-#include "OblateSpheroid.h"
+#include "BodyData.h"
 #include "Constants.h"
 
 
-MaRC::CosPhaseImage::CosPhaseImage(std::shared_ptr<OblateSpheroid> body,
+MaRC::CosPhaseImage::CosPhaseImage(std::shared_ptr<BodyData> body,
                                    double sub_observ_lat,
                                    double sub_observ_lon,
                                    double sub_solar_lat,
@@ -75,10 +74,9 @@ MaRC::CosPhaseImage::is_visible(double lat, double lon) const
     // This implementation is as the same as the one used by the
     // MuImage class.
 
-    return MaRC::MuImage::is_visible_i(*this->body_,
-                                       this->sub_observ_lat_,
-                                       this->sub_observ_lon_,
-                                       lat,
-                                       lon,
-                                       this->range_);
+    return this->body_->mu(this->sub_observ_lat_,
+                           this->sub_observ_lon_,
+                           lat,
+                           lon,
+                           this->range_) >= 0;
 }

--- a/lib/MaRC/CosPhaseImage.h
+++ b/lib/MaRC/CosPhaseImage.h
@@ -32,7 +32,7 @@
 
 namespace MaRC
 {
-    class OblateSpheroid;
+    class BodyData;
 
     /**
      * @class CosPhaseImage
@@ -50,9 +50,8 @@ namespace MaRC
 
         /// Constructor
         /**
-         * @param[in] body           @c OblateSpheroid object
-         *                           representing the body being
-         *                           mapped.
+         * @param[in] body           Object representing the body
+         *                           being mapped.
          * @param[in] sub_observ_lat Bodycentric sub-observer latitude
          *                           in degrees.
          * @param[in] sub_observ_lon Sub-observer longitude in
@@ -67,7 +66,7 @@ namespace MaRC
          *                           cosines after the scaling factor
          *                           has been applied.
          */
-        CosPhaseImage(std::shared_ptr<OblateSpheroid> body,
+        CosPhaseImage(std::shared_ptr<BodyData> body,
                       double sub_observ_lat,
                       double sub_observ_lon,
                       double sub_solar_lat,
@@ -88,20 +87,12 @@ namespace MaRC
 
         /// Is point at given latitude and longitude visible to the
         /// observer?
-        /**
-         * @see MaRC::VirtualImage::is_visible().
-         */
         virtual bool is_visible(double lat, double lon) const;
 
     private:
 
         /// Object representing the body being mapped.
-        /**
-         * @note OblateSpheroid is used instead of BodyData since some
-         *       code in this implementation assumes that the body is
-         *       modeled as an oblate spheroid.
-         */
-        std::shared_ptr<OblateSpheroid> const body_;
+        std::shared_ptr<BodyData> const body_;
 
         /// Bodycentric sub-observer latitude in radians.
         double const sub_observ_lat_;

--- a/lib/MaRC/Geometry.cpp
+++ b/lib/MaRC/Geometry.cpp
@@ -30,8 +30,8 @@
 
 void
 MaRC::Geometry::RotX(double angle,
-                     DVector const & vec,
-                     DVector & rotated)
+                     DVector const & v,
+                     DVector & r)
 {
     double const cosine = std::cos(angle);
     double const sine   = std::sin(angle);
@@ -40,15 +40,15 @@ MaRC::Geometry::RotX(double angle,
     // { 0,  cos(angle), sin(angle) } * { vec[1] }
     // { 0, -sin(angle), cos(angle} }   { vec[2] }
 
-    rotated[0] =  vec[0];
-    rotated[1] =  vec[1] * cosine + vec[2] * sine;
-    rotated[2] = -vec[1] * sine   + vec[2] * cosine;
+    r[0] =  v[0];
+    r[1] =  v[1] * cosine + v[2] * sine;
+    r[2] = -v[1] * sine   + v[2] * cosine;
 }
 
 void
 MaRC::Geometry::RotY(double angle,
-                     DVector const & vec,
-                     DVector & rotated)
+                     DVector const & v,
+                     DVector & r)
 {
     double const cosine = std::cos(angle);
     double const sine   = std::sin(angle);
@@ -57,15 +57,15 @@ MaRC::Geometry::RotY(double angle,
     // { 0,          1,           0 } * { vec[1] }
     // { sin(angle), 0,  cos(angle} }   { vec[2] }
 
-    rotated[0] = vec[0] * cosine - vec[2] * sine;
-    rotated[1] = vec[1];
-    rotated[2] = vec[0] * sine   + vec[2] * cosine;
+    r[0] = v[0] * cosine - v[2] * sine;
+    r[1] = v[1];
+    r[2] = v[0] * sine   + v[2] * cosine;
 }
 
 void
 MaRC::Geometry::RotZ(double angle,
-                     DVector const & vec,
-                     DVector &rotated)
+                     DVector const & v,
+                     DVector &r)
 {
     double const cosine = std::cos(angle);
     double const sine   = std::sin(angle);
@@ -74,9 +74,9 @@ MaRC::Geometry::RotZ(double angle,
     // { -sin(angle), cos(angle}, 0 } * { vec[1] }
     // {  0,          0,          1 }   { vec[2] }
 
-    rotated[0] =  vec[0] * cosine + vec[1] * sine;
-    rotated[1] = -vec[0] * sine   + vec[1] * cosine;
-    rotated[2] =  vec[2];
+    r[0] =  v[0] * cosine + v[1] * sine;
+    r[1] = -v[0] * sine   + v[1] * cosine;
+    r[2] =  v[2];
 }
 
 MaRC::DMatrix
@@ -143,16 +143,16 @@ MaRC::Geometry::RotZMatrix(double angle)
 }
 
 double
-MaRC::Geometry::Magnitude(DVector const & vec)
+MaRC::Geometry::Magnitude(DVector const & v)
 {
-    return MaRC::hypot(vec[0], vec[1], vec[2]);
+    return MaRC::hypot(v[0], v[1], v[2]);
 }
 
 void
-MaRC::Geometry::toUnitVector(DVector & vec)
+MaRC::Geometry::toUnitVector(DVector & v)
 {
-    double const mag = Geometry::Magnitude(vec);
+    double const mag = Geometry::Magnitude(v);
 
     for(std::size_t i = 0; i < 3; ++i)
-        vec[i] /= mag;
+        v[i] /= mag;
 }

--- a/lib/MaRC/Geometry.cpp
+++ b/lib/MaRC/Geometry.cpp
@@ -23,64 +23,10 @@
 
 #include "Geometry.h"
 #include "Matrix.h"
-#include "config.h"  // For MARC_HAS_3_PARAM_STD_HYPOT
+#include "Mathematics.h"
 
 #include <cmath>
-#include <type_traits>  // For std::is_floating_point<>
 
-namespace MaRC
-{
-    namespace
-    {
-#ifndef MARC_HAS_3_PARAM_STD_HYPOT
-        /**
-         * @brief Distance of (x,y,z) from the origin.
-         *
-         * Compute the distance of the point in space
-         * (@a x, @a y, @a z) from the origin (0, 0, 0).  This
-         * function is implemented in terms of the two-parameter
-         * @c std::hypot() to leverage its ability to perform the
-         * operation without floating point underflow or overflow, as
-         * well as its excellent floating point error
-         * characteristics.
-         *
-         * @param[in] x First  coordinate in space.
-         * @param[in] y Second coordinate in space.
-         * @param[in] z Third  coordinate in space.
-         *
-         * @return Distance from the origin to the point in space
-         *         (@a x,@a y, @a z), i.e. the equivalent of the
-         *         square root of the sum of the squares of each
-         *         coordinate @c sqrt(x*x+y*y+z*z).
-         *
-         * @deprecated This implementation of the three-parameter
-         *             @c std::hypot() will be dropped once we start
-         *             using C++17 features in MaRC.
-         */
-        template <typename T>
-        typename std::enable_if_t<std::is_floating_point<T>::value, T>
-        hypot(T x, T y, T z)
-        {
-            /*
-              Implement the missing three parameter std::hypot()
-              function by nesting two std::hypot() calls.  Given a
-              hypotenuse in the x-y plane orthogonal to the z-axis:
-                  std::hypot(x,y)   = sqrt(x*x + y*y)
-              and:
-                  std::hypot(x,y,z) = sqrt(x*x + y*y + z*z)
-              We have:
-                  std::hypot(std::hypot(x, y), z)
-                  = sqrt((sqrt(x*x + y*y) * sqrt(x*x + y*y)) + z*z)
-                  = sqrt(x*x + y*y + z*z)
-                  = std::hypot(x, y, z)
-             */
-            return std::hypot(std::hypot(x, y), z);
-        }
-#endif  // !MARC_HAS_3_PARAM_STD_HYPOT
-
-        using std::hypot;
-    }
-}
 
 void
 MaRC::Geometry::RotX(double angle,

--- a/lib/MaRC/Geometry.h
+++ b/lib/MaRC/Geometry.h
@@ -27,53 +27,132 @@
 #ifndef MARC_GEOMETRY_H
 #define MARC_GEOMETRY_H
 
-#include <cstddef>
-
 #include <MaRC/Matrix.h>
+
+#include <cstddef>
 
 
 namespace MaRC
 {
     template <typename T, std::size_t M, std::size_t N> class Matrix;
+
+    /**
+     * @name Convenience Vector and Matrix Types
+     *
+     * @c Vector and @c Matrix types used heavily through out the MaRC
+     * library.
+     */
+    //@{
     typedef Vector<double, 3> DVector;
     typedef Matrix<double, 3, 3> DMatrix;
+    //@}
 
     /**
      * @namespace Geometry
      *
-     * @brief MaRC geometry related functions.
+     * @brief Geometry related functions.
      */
     namespace Geometry
     {
-        // All coordinate transformations assume a right-handed
-        // coordinate system.
-
-        /// Rotate about x-axis.
-        void RotX(double, DVector const &, DVector &);
+        /**
+         * @name Coordinate System Rotations
+         *
+         * @brief Set functions that perform or generate coordinate
+         *        system rotations.
+         *
+         * These functions either perform or generate @em coordinate
+         * @em system @em rotations, as opposed to rotations in a
+         * fixed coordinate system where the rotation matrix would be
+         * the transpose of the coordinate system rotation matrix.
+         *
+         * All coordinate transformations assume a right-handed
+         * coordinate system, meaning a positive angle causes
+         * counterclockwise rotation to occur about a given axis.
+         *
+         * All angles are in radians.
+         */
+        //@{
+        /// Rotate vector about x-axis.
+        /**
+         * @param[in]  angle Angle about the x-axis through which the
+         *                   coordinate system will be rotated.
+         * @param[in]  v     Vector in the original coordinate
+         *                   system.
+         * @param[out] r     Vector in the rotated coordinate system.
+         */
+        void RotX(double angle, DVector const & v, DVector & r);
 
         /// Rotate about y-axis.
-        void RotY(double, DVector const &, DVector &);
+        /**
+         * @param[in]  angle Angle about the y-axis through which the
+         *                   coordinate system will be rotated.
+         * @param[in]  v     Vector in the original coordinate
+         *                   system.
+         * @param[out] r     Vector in the rotated coordinate system.
+         */
+        void RotY(double angle, DVector const & v, DVector & r);
 
         /// Rotate about z-axis.
-        void RotZ(double, DVector const &, DVector &);
+        /**
+         * @param[in]  angle Angle about the z-axis through which the
+         *                   coordinate system will be rotated.
+         * @param[in]  v     Vector in the original coordinate
+         *                   system.
+         * @param[out] r     Vector in the rotated coordinate system.
+         */
+        void RotZ(double angle, DVector const & v, DVector & r);
 
-        /// Return a transformation matrix that rotates about the
-        /// x-axis.
+        /// Return a transformation matrix that rotates a coordinate
+        /// system about the x-axis.
+        /**
+         * @param[in] angle Angle about the x-axis through which the
+         *                  returned rotation matrix will rotate a
+         *                  coordinate system.
+         *
+         * @return Matrix that will rotate a coordinate system
+         *         @a angle radians about the x-axis.
+         */
         DMatrix RotXMatrix(double angle);
 
-        /// Return a transformation matrix that rotates about the
-        /// y-axis.
+        /// Return a transformation matrix that rotates a coordinate
+        /// system about the y-axis.
+        /**
+         * @param[in] angle Angle about the y-axis through which the
+         *                  returned rotation matrix will rotate a
+         *                  coordinate system.
+         *
+         * @return Matrix that will rotate a coordinate system
+         *         @a angle radians about the y-axis.
+         */
         DMatrix RotYMatrix(double angle);
 
-        /// Return a transformation matrix that rotates about the
-        /// z-axis.
+        /// Return a transformation matrix that rotates a coordinate
+        /// system about the z-axis.
+        /**
+         * @param[in] angle Angle about the z-axis through which the
+         *                  returned rotation matrix will rotate a
+         *                  coordinate system.
+         *
+         * @return Matrix that will rotate a coordinate system
+         *         @a angle radians about the z-axis.
+         */
         DMatrix RotZMatrix(double angle);
+        //@}
 
-        /// Obtain magnitude of vector of type @c double.
-        double Magnitude(DVector const &);
+        /// Obtain magnitude of vector.
+        /**
+         * @param[in] v Vector for which the magnitude will be
+         *            calculated.
+         *
+         * @return Magnitude of vector @a v.
+         */
+        double Magnitude(DVector const & v);
 
         /// Convert a vector of type double to a unit vector.
-        void toUnitVector(DVector &);
+        /**
+         * @param[in,out] v Vector to convert to a unit vector.
+         */
+        void toUnitVector(DVector & v);
     }
 }
 

--- a/lib/MaRC/LongitudeImage.cpp
+++ b/lib/MaRC/LongitudeImage.cpp
@@ -24,6 +24,8 @@
 #include "LongitudeImage.h"
 #include "Constants.h"
 
+#include <cmath>
+
 
 MaRC::LongitudeImage::LongitudeImage(double scale, double offset)
     : VirtualImage(scale, offset)
@@ -35,12 +37,19 @@ MaRC::LongitudeImage::read_data_i(double /* lat */,
                                   double lon,
                                   double & data) const
 {
+    static constexpr int maxlon = 360;  // 0 to 360 degree range.
+
     data = lon / C::degree;  // Convert radians to degrees.
 
+    // Make sure the longitude is in the +/-360 degree range.
+    data = std::fmod(data, maxlon);
+
+    // Data is now in the +/- 360 range but we need it to be
+    // positive.  fmod() retains the sign of its first argument so
+    // shift the negative longitude to its positive equivalent (not
+    // the same as absolute value!).
     if (data < 0)
-        data += 360;
-    else if (data >= 360)
-        data -= 360;
+        data += maxlon;
 
     return true;
 }

--- a/lib/MaRC/Mathematics.h
+++ b/lib/MaRC/Mathematics.h
@@ -29,6 +29,8 @@
 #ifndef MARC_MATHEMATICS_H
 #define MARC_MATHEMATICS_H
 
+#include "MaRC/config.h"  // For MARC_HAS_3_PARAM_STD_HYPOT
+
 #include <limits>
 #include <type_traits>
 #include <utility>
@@ -37,6 +39,53 @@
 
 namespace MaRC
 {
+#ifndef MARC_HAS_3_PARAM_STD_HYPOT
+    /**
+     * @brief Distance of (x,y,z) from the origin.
+     *
+     * Compute the distance of the point in space (@a x, @a y, @a z)
+     * from the origin (0, 0, 0).  This function is implemented in
+     * terms of the two-parameter @c std::hypot() to leverage its
+     * ability to perform the operation without floating point
+     * underflow or overflow, as well as its excellent floating point
+     * error characteristics.
+     *
+     * @param[in] x First  coordinate in space.
+     * @param[in] y Second coordinate in space.
+     * @param[in] z Third  coordinate in space.
+     *
+     * @return Distance from the origin to the point in space (@a x,
+     *         @a y, @a z), i.e. the equivalent of the square root of
+     *         the sum of the squares of each coordinate @c
+     *         sqrt(x*x+y*y+z*z).
+     *
+     * @deprecated This implementation of the three-parameter
+     *             @c std::hypot() will be dropped once we start
+     *             using C++17 features in MaRC.
+     */
+    template <typename T>
+    typename std::enable_if<std::is_floating_point<T>::value, T>::type
+    hypot(T x, T y, T z)
+    {
+        /*
+          Implement the missing three parameter std::hypot() function
+          by nesting two std::hypot() calls.  This works since:
+          Given:
+              std::hypot(x,y)   = sqrt(x*x + y*y)
+          and:
+              std::hypot(x,y,z) = sqrt(x*x + y*y + z*z)
+          We have:
+              std::hypot(std::hypot(x, y), z)
+                  = sqrt((sqrt(x*x + y*y) * sqrt(x*x + y*y)) + z*z)
+                  = sqrt(x*x + y*y + z*z) =
+                  = std::hypot(x, y, z)
+        */
+        return std::hypot(std::hypot(x, y), z);
+    }
+#endif  // !MARC_HAS_3_PARAM_STD_HYPOT
+
+    using std::hypot;
+
     /**
      * @brief Compare two floating numbers for equality.
      *

--- a/lib/MaRC/Mathematics.h
+++ b/lib/MaRC/Mathematics.h
@@ -208,11 +208,11 @@ namespace MaRC
      *      Recipes in C", 1992, by Press, Teukolsky, Veterrling
      *      and Flannery for a discussion on how this approach works.
      *
-     * @param[in]     a     Coefficient of the quadratic term.
-     * @param[in]     b     Coefficient of the linear term.
-     * @param[in]     c     Coefficient of the constant term.
-     * @param[in,out] roots The roots of the quadratic equation are
-     *                      returned through this variable.
+     * @param[in]  a     Coefficient of the quadratic term.
+     * @param[in]  b     Coefficient of the linear term.
+     * @param[in]  c     Coefficient of the constant term.
+     * @param[out] roots The roots of the quadratic equation are
+     *                   returned through this variable.
      *
      * @returns @c true if real roots were found, @c false otherwise.
      */

--- a/lib/MaRC/Mu0Image.cpp
+++ b/lib/MaRC/Mu0Image.cpp
@@ -22,13 +22,13 @@
  */
 
 #include "Mu0Image.h"
-#include "OblateSpheroid.h"
+#include "BodyData.h"
 #include "Constants.h"
 
 #include <cmath>
 
 
-MaRC::Mu0Image::Mu0Image(std::shared_ptr<OblateSpheroid> body,
+MaRC::Mu0Image::Mu0Image(std::shared_ptr<BodyData> body,
                          double sub_solar_lat,
                          double sub_solar_lon,
                          double scale,
@@ -48,46 +48,14 @@ MaRC::Mu0Image::read_data_i(double lat, double lon, double & data) const
                             lat,
                             lon);
 
-  return true;
+    return true;
 }
 
 bool
 MaRC::Mu0Image::is_visible(double lat, double lon) const
 {
-    /**
-     * @todo This is ugly.  The visibility check is specific to an
-     *       oblate spheroid.  It should really be moved to
-     *       OblateSpheroid strategy.  Alternatively, is there any
-     *       reason why we can't check if this->body_->mu0() < 0 to
-     *       determine if the given latitude and longitude isn't
-     *       visible?  That would allow us to drop the OblateSpheroid
-     *       dependency entirely.
-     */
-    double const latg = this->body_->graphic_latitude(lat);
-
-    // When creating cosine of incidence angle map use terminator
-    // instead of limb so that entire incidence angle map is created
-    // as opposed to just the area visible to the observer.
-    double const cosine = std::tan(latg) * std::tan(this->sub_solar_lat_);
-
-    if (cosine >= -1 && cosine <= 1) {
-        // Partial range of longitudes are visible
-      double const lower = this->sub_solar_lon_ - std::abs(std::acos(-cosine));
-      double const upper = this->sub_solar_lon_ + std::abs(std::acos(-cosine));
-
-      double l = lon;
-
-      if (l < lower)
-          l += C::_2pi;
-      else if (l > upper)
-          l -= C::_2pi;
-
-      if (l >= lower && l <= upper)
-          return true;
-    } else if (cosine < -1) {
-        // Full 360 degree visible longitude range
-        return true;
-    }
-
-  return false;
+    return this->body_->mu0(this->sub_solar_lat_,
+                            this->sub_solar_lon_,
+                            lat,
+                            lon) >= 0;
 }

--- a/lib/MaRC/Mu0Image.h
+++ b/lib/MaRC/Mu0Image.h
@@ -32,7 +32,7 @@
 
 namespace MaRC
 {
-    class OblateSpheroid;
+    class BodyData;
 
     /**
      * @class Mu0Image
@@ -44,9 +44,6 @@ namespace MaRC
      * sun-local-normal (incidence) angle, &mu;<SUB>0</SUB>, on the
      * body being mapped.  The sun is assumed to be an infinite
      * distance away.
-     *
-     * @note This implementation requires that the body under
-     *       observation is modeled as an oblate spheroid.
      */
     class Mu0Image : public VirtualImage
     {
@@ -54,8 +51,7 @@ namespace MaRC
 
         /// Constructor
         /**
-         * @param[in] body          @c OblateSpheroid object
-         *                          representing the body being
+         * @param[in] body          Object representing the body being
          *                          mapped.
          * @param[in] sub_solar_lat Bodycentric sub-solar latitude in
          *                          degrees.
@@ -66,7 +62,7 @@ namespace MaRC
          *                          cosines after the scaling factor
          *                          has been applied.
          */
-        Mu0Image(std::shared_ptr<OblateSpheroid> body,
+        Mu0Image(std::shared_ptr<BodyData> body,
                  double sub_solar_lat,
                  double sub_solar_lon,
                  double scale,
@@ -78,8 +74,8 @@ namespace MaRC
         /**
          * @see MaRC::VirtualImage::read_data_i().
          */
-        virtual bool read_data_i(double Latitude,
-                                 double Longitude,
+        virtual bool read_data_i(double lat,
+                                 double lon,
                                  double & Data) const;
 
         /// Is point at given latitude and longitude visible to the
@@ -92,12 +88,7 @@ namespace MaRC
     private:
 
         /// Object representing the body being mapped.
-        /**
-         * @note OblateSpheroid is used instead of BodyData since some
-         *       code in this implementation assumes that the body is
-         *       modeled as an oblate spheroid.
-         */
-        std::shared_ptr<OblateSpheroid> const body_;
+        std::shared_ptr<BodyData> const body_;
 
         /// Bodycentric sub-solar latitude in radians.
         const double sub_solar_lat_;

--- a/lib/MaRC/MuImage.h
+++ b/lib/MaRC/MuImage.h
@@ -32,7 +32,7 @@
 
 namespace MaRC
 {
-    class OblateSpheroid;
+    class BodyData;
 
     /**
      * @class MuImage
@@ -49,9 +49,8 @@ namespace MaRC
 
         /// Constructor
         /**
-         * @param[in] body           @c OblateSpheroid object
-         *                           representing the body being
-         *                           mapped.
+         * @param[in] body           Object representing the body
+         *                           being mapped.
          * @param[in] sub_observ_lat Bodycentric sub-observer latitude
          *                           in degrees.
          * @param[in] sub_observ_lon Sub-observer longitude in
@@ -64,26 +63,12 @@ namespace MaRC
          *                           cosines after the scaling factor
          *                           has been applied.
          */
-        MuImage(std::shared_ptr<OblateSpheroid> body,
+        MuImage(std::shared_ptr<BodyData> body,
                 double sub_observ_lat,
                 double sub_observ_lon,
                 double range,
                 double scale,
                 double offset);
-
-        /**
-         * Underlying implementation for
-         * @c MaRC::MuImage::is_visible() method.
-         *
-         * @note This method is @c static since it is also called
-         *       @c MaRC::CosPhaseImage::is_visible().
-         */
-        static bool is_visible_i(OblateSpheroid const & body,
-                                 double sub_observ_lat,
-                                 double sub_observ_lon,
-                                 double lat,
-                                 double lon,
-                                 double range);
 
     private:
 
@@ -105,12 +90,7 @@ namespace MaRC
     private:
 
         /// Object representing the body being mapped.
-        /**
-         * @note OblateSpheroid is used instead of BodyData since some
-         *       code in this implementation assumes that the body is
-         *       modeled as an oblate spheroid.
-         */
-        std::shared_ptr<OblateSpheroid> const body_;
+        std::shared_ptr<BodyData> const body_;
 
         /// Bodycentric sub-observer latitude in radians.
         double const sub_observ_lat_;

--- a/lib/MaRC/OblateSpheroid.cpp
+++ b/lib/MaRC/OblateSpheroid.cpp
@@ -206,7 +206,8 @@ MaRC::OblateSpheroid::mu(double sub_observ_lat,
                          double lon,
                          double range) const
 {
-    // Compute the local normal-observer angle - Emission Angle (Mu)
+    // Compute Mu, the cosine of local normal-observer (emission)
+    // angle.
 
   double const latg = this->graphic_latitude(lat);
   double const ellipse_radius = this->centric_radius(lat);
@@ -232,7 +233,7 @@ MaRC::OblateSpheroid::mu0(double sub_solar_lat,
                           double lat,
                           double lon) const
 {
-    // Compute the sun-local normal angle - Incidence Angle (Mu0)
+    // Compute Mu0, the cosine of sun-local normal (incidence) angle.
 
     double const latg = this->graphic_latitude(lat);
 
@@ -254,8 +255,8 @@ MaRC::OblateSpheroid::cos_phase(double sub_observ_lat,
                                 double lon,
                                 double range) const
 {
-    // Compute the Sun-point on surface of body-Observer angle
-    // (phase angle)
+    // Compute the cosine of the Sun-point on surface of body-Observer
+    // angle, i.e cosine of the phase angle Phi.
 
   double const ellipse_radius = this->centric_radius(lat);
 

--- a/lib/MaRC/OblateSpheroid.cpp
+++ b/lib/MaRC/OblateSpheroid.cpp
@@ -97,7 +97,7 @@ MaRC::OblateSpheroid::initialize_radii(double eq_rad,
     // Set flattening.
     // ----------------------------------------------
 
-    // flattening <  0 ----> eq_rad < pol_rad <----- Not valid
+    // flattening <  0 ----> Prolate Spheroid <----- Not valid
     // flattening > 0 < 1 -> Oblate Spheroid
     // flattening == 0 ----> Sphere
     // flattening == 1 ----> Disc!!  <--- Not valid

--- a/lib/MaRC/OblateSpheroid.cpp
+++ b/lib/MaRC/OblateSpheroid.cpp
@@ -135,24 +135,53 @@ MaRC::OblateSpheroid::initialize_radii(double eq_rad,
     }
 }
 
-inline double
+double
 MaRC::OblateSpheroid::centric_radius(double lat) const
 {
-    /**
-     * @todo Can we leverage std::hypot() here to reduce floating
-     *       point error?  If not, at least switch to an
-     *       implementation that avoid underflow and overflow.
-     */
-    double const er2     = this->eq_rad_ * this->eq_rad_;
-    double const pr2     = this->pol_rad_ * this->pol_rad_;
-    double const sin_lat = std::sin(lat);
+    /*
+      Given a bodycentric latitude and longitude for a point (x, y, z)
+      on the surface of a spheroid:
 
-    return
-        this->eq_rad_ * this->pol_rad_ /
-        std::sqrt((er2 - pr2) * sin_lat * sin_lat + pr2);
+          x = r * cos(lat) * cos(lon)
+          y = r * cos(lat) * sin(lon)
+          z = r * sin(lat)
+
+      Assume longitude zero is along the observer optical axis, we
+      have:
+
+          x = r * cos(lat)
+          y = 0
+          z = r * sin(lat)
+
+      The Cartesian equation for an oblate spheroid is:
+
+           2    2    2
+          x  + y    z
+          ------- + -- = 1
+             2       2
+            a       c
+
+      We end up with:
+
+                       2                  2
+         (r * cos(lat))  +  (r * sin(lat))
+         ---------------    --------------- = 1
+                 2                   2
+                a                   c
+
+      and:
+
+                            1
+        r = -----------------------------------
+                             2               2
+            sqrt((cos(lat)/a)  + (sin(lat)/c) )
+
+    */
+    return 1 / MaRC::hypot(std::cos(lat) / this->eq_rad_,
+                           std::sin(lat) / this->pol_rad_);
 }
 
-inline double
+double
 MaRC::OblateSpheroid::centric_latitude(double lat) const
 {
     return
@@ -161,7 +190,7 @@ MaRC::OblateSpheroid::centric_latitude(double lat) const
                   * std::tan(lat));
 }
 
-inline double
+double
 MaRC::OblateSpheroid::graphic_latitude(double lat) const
 {
     return
@@ -248,7 +277,7 @@ MaRC::OblateSpheroid::cos_phase(double sub_observ_lat,
                  std::cos(lat) * std::cos(sub_observ_lon - lon)));
 }
 
-inline double
+double
 MaRC::OblateSpheroid::M(double lat)
 {
     double const fe2 =
@@ -260,7 +289,7 @@ MaRC::OblateSpheroid::M(double lat)
       / std::pow(1 - fe2 * sin_latg * sin_latg, 1.5);
 }
 
-inline double
+double
 MaRC::OblateSpheroid::N (double lat)
 {
     double const sin_latg = std::sin(this->graphic_latitude(lat));

--- a/lib/MaRC/PhotoImage.cpp
+++ b/lib/MaRC/PhotoImage.cpp
@@ -176,8 +176,8 @@ MaRC::PhotoImage::is_visible(double lat, double lon) const
           side of the planet, and if it's negative, the point is on
           the dark side of the planet.
         */
-        || (flags::check (this->flags_, USE_TERMINATOR)
-            && this->body_->mu0(this->sub_solar_lat_,
+        && (!flags::check(this->flags_, USE_TERMINATOR)
+            || this->body_->mu0(this->sub_solar_lat_,
                                 this->sub_solar_lon_,
                                 lat,
                                 lon) >= 0);
@@ -1346,16 +1346,14 @@ MaRC::PhotoImage::latlon2pix(double lat,
 {
     double const radius = this->body_->centric_radius(lat);
 
-    double longitude;
-
-    if (this->body_->prograde ())
-        longitude = this->sub_observ_lon_ - lon;
+    if (this->body_->prograde())
+        lon  = this->sub_observ_lon_ - lon;
     else
-        longitude = lon - this->sub_observ_lon_;
+        lon -= this->sub_observ_lon_;
 
     DVector Coord;
-    Coord[0] =  radius * std::cos(lat) * std::sin(longitude);
-    Coord[1] = -radius * std::cos(lat) * std::cos(longitude);
+    Coord[0] =  radius * std::cos(lat) * std::sin(lon);
+    Coord[1] = -radius * std::cos(lat) * std::cos(lon);
     Coord[2] =  radius * std::sin(lat);
 
     DVector const Obs(Coord - this->range_b_);

--- a/lib/MaRC/PhotoImage.cpp
+++ b/lib/MaRC/PhotoImage.cpp
@@ -908,21 +908,9 @@ MaRC::PhotoImage::set_km_per_pixel()
 
         this->km_per_pixel_ =
             this->range_ /
-            std::sqrt(this->focal_length_pixels_
-                      * this->focal_length_pixels_
-                      + (this->OA_s_ - this->sample_center_)
-                      * (this->OA_s_ - this->sample_center_)
-                      + (this->OA_l_ - this->line_center_)
-                      * (this->OA_l_ - this->line_center_));
-
-//       std::cout << "focal_length = " << this->focal_length_ << '\n'
-//                 << "scale        = " << this->scale_        << '\n'
-//                 << "OA_s         = " << this->OA_s_         << '\n'
-//                 << "OA_l         = " << this->OA_l_         << '\n'
-//                 << "sample_center= " << this->sample_center_<< '\n'
-//                 << "line_center  = " << this->line_center_  << '\n'
-//                 << "km_per_pixel = " << this->km_per_pixel_ << '\n'
-//                 << "range        = " << this->range_        << '\n';
+            MaRC::hypot(this->OA_s_ - this->sample_center_,
+                        this->focal_length_pixels_,
+                        this->OA_l_ - this->line_center_);
     } else if (this->km_per_pixel_ <= 0) {
         std::cerr
             << "ERROR: Attempt to compute number of kilometers per pixel\n"
@@ -1370,8 +1358,6 @@ MaRC::PhotoImage::latlon2pix(double lat,
     // If this assertion does trigger that would mean the point is on
     // other side of image plane / body, which indicates a problem
     // with the math!
-    std::cout << "Rotated[1] =\t" << Rotated[1] << '\n'
-              << "normal_range =\t" << this->normal_range_ << '\n';
     assert(Rotated[1] <= this->normal_range_);
 
     x = Rotated[0] / Rotated[1] * this->focal_length_pixels_;

--- a/lib/MaRC/PhotoImage.cpp
+++ b/lib/MaRC/PhotoImage.cpp
@@ -1377,6 +1377,8 @@ MaRC::PhotoImage::latlon2pix(double lat,
     // If this assertion does trigger that would mean the point is on
     // other side of image plane / body, which indicates a problem
     // with the math!
+    std::cout << "Rotated[1] =\t" << Rotated[1] << '\n'
+              << "normal_range =\t" << this->normal_range_ << '\n';
     assert(Rotated[1] <= this->normal_range_);
 
     x = Rotated[0] / Rotated[1] * this->focal_length_pixels_;

--- a/lib/MaRC/PhotoImage.cpp
+++ b/lib/MaRC/PhotoImage.cpp
@@ -148,37 +148,42 @@ MaRC::PhotoImage::operator==(PhotoImage const & img)
 bool
 MaRC::PhotoImage::is_visible(double lat, double lon) const
 {
-    /* mu is the cosine of the angle between
-     * -- the vector from the given point to the observer
-     * -- the normal vector to the surface at the given point
-     * For a convex body, if this is positive, the point is
-     * on the visible side of the planet, and if it's negative,
-     * the point is on the far side of the planet.
-     */
-    if (this->body_->mu(this->sub_observ_lat_,
+    /*
+      mu is the cosine of the angle between:
+
+      -- the vector from the given point to the observer
+      -- the normal vector to the surface at the given point
+
+      For a convex body, if this is positive, the point is on the
+      visible side of the planet, and if it's negative, the point is
+      on the far side of the planet.
+    */
+    return
+        this->body_->mu(this->sub_observ_lat_,
                         this->sub_observ_lon_,
                         lat,
                         lon,
-                        this->range_) < 0
+                        this->range_) >= 0
 
-        /* mu0 is the angle between
-         * -- the vector from the given point to the sun
-         * -- the normal vector to the surface at the given point
-         * The sun is assumed to be an infinite distance away.
-         * For a convex body, if this is positive, the point is
-         * on the lit side of the planet, and if it's negative,
-         * the point is on the dark side of the planet.
-         */
+        /*
+          mu0 is the angle between:
+
+          -- the vector from the given point to the sun
+          -- the normal vector to the surface at the given point
+
+          The sun is assumed to be an infinite distance away.  For a
+          convex body, if this is positive, the point is on the lit
+          side of the planet, and if it's negative, the point is on
+          the dark side of the planet.
+        */
         || (flags::check (this->flags_, USE_TERMINATOR)
             && this->body_->mu0(this->sub_solar_lat_,
                                 this->sub_solar_lon_,
                                 lat,
-                                lon) < 0)) {
-        return false;
-    }
+                                lon) >= 0);
 
-    // Passed both the far-side and (if requested) the dark-side check.
-    return true;
+     // Visible if both the far-side and (if requested) the dark-side
+     // checks passed.
 }
 
 int

--- a/lib/MaRC/PhotoImage.cpp
+++ b/lib/MaRC/PhotoImage.cpp
@@ -1351,6 +1351,15 @@ MaRC::PhotoImage::latlon2pix(double lat,
     else
         lon -= this->sub_observ_lon_;
 
+    /**
+     * @todo Confirm that Coord[0] and Coord[1] are not swapped,
+     *       i.e. 90 degrees off in the x-y plane!
+     *       @par
+     *       Swapping the two prevents the below @c assert() from
+     *       being triggered, but it's not yet clear if the
+     *       @c normal_range_ value is incorrect or if the @c Coord
+     *       vector is incorrect.
+     */
     DVector Coord;
     Coord[0] =  radius * std::cos(lat) * std::sin(lon);
     Coord[1] = -radius * std::cos(lat) * std::cos(lon);

--- a/lib/MaRC/PhotoImage.cpp
+++ b/lib/MaRC/PhotoImage.cpp
@@ -1222,9 +1222,7 @@ MaRC::PhotoImage::read_data(double lat,
 
     double x = 0, z = 0;
 
-    if (!this->latlon2pix(lat, lon, x, z)
-        || x < 0    // Prevent integer underflow since we're casting
-        || z < 0)   // to an unsigned integer below.
+    if (!this->latlon2pix(lat, lon, x, z))
         return false;
 
     std::size_t const i = static_cast<std::size_t>(std::round(x));
@@ -1388,7 +1386,9 @@ MaRC::PhotoImage::latlon2pix(double lat,
     // Convert from object space to image space.
     this->geometric_correction_->object_to_image(z, x);
 
-    return true;
+    // x and z are both positive if the point at the given latitude
+    // and longitude is in the image.
+    return x >= 0 && z >= 0;
 }
 
 void

--- a/lib/MaRC/PhotoImage.cpp
+++ b/lib/MaRC/PhotoImage.cpp
@@ -1179,7 +1179,7 @@ MaRC::PhotoImage::emi_ang_limit(double angle)
     else if (angle == static_cast<double>(90)) {
         // Value equal to 90 means no cut-off, so we don't
         // switch on the emission angle cut-off code.
-        flags::unset (this->flags_, EMI_ANG_LIMIT);
+        flags::unset(this->flags_, EMI_ANG_LIMIT);
     } else {
         std::cerr << "Incorrect value value passed to EmiAngLimit routine: "
                   << angle << '\n';
@@ -1362,6 +1362,15 @@ MaRC::PhotoImage::latlon2pix(double lat,
 
     // Convert to observer coordinates.
     DVector const Rotated(this->body2observ_ * Obs);
+
+    // This assertion should never be triggered since we verified that
+    // the point at the given latitude and longitude is visible before
+    // calling this method.
+    //
+    // If this assertion does trigger that would mean the point is on
+    // other side of image plane / body, which indicates a problem
+    // with the math!
+    assert(Rotated[1] <= this->normal_range_);
 
     x = Rotated[0] / Rotated[1] * this->focal_length_pixels_;
     z = Rotated[2] / Rotated[1] * this->focal_length_pixels_;

--- a/lib/MaRC/PhotoImage.h
+++ b/lib/MaRC/PhotoImage.h
@@ -60,11 +60,10 @@ namespace MaRC
          */
         enum sflags
         {
-            EMI_ANG_LIMIT    = 1 << 0,
-            LATLON_AT_CENTER = 1 << 1,
-            OA_SET           = 1 << 2,
-            EXTREMA_SET      = 1 << 3,
-            USE_TERMINATOR   = 1 << 4
+            LATLON_AT_CENTER = 1 << 0,
+            OA_SET           = 1 << 1,
+            EXTREMA_SET      = 1 << 2,
+            USE_TERMINATOR   = 1 << 3
         };
 
         /// Constructor
@@ -524,8 +523,12 @@ namespace MaRC
         /// Longitude at picture center
         double lon_at_center_;
 
-        /// Cosine of emission angle outside of which no data will be
-        /// plotted / retrieved.
+        /**
+         * The cosine, &mu; of the emission angle outside of which no
+         * data will be plotted / retrieved.
+         *
+         * This is used to avoid mapping data close to the limb.
+         */
         double mu_limit_;
 
         /// Minimum latitude visible on body.

--- a/lib/MaRC/PhotoImage.h
+++ b/lib/MaRC/PhotoImage.h
@@ -232,6 +232,11 @@ namespace MaRC
         void interpolate(bool enable);
 
         /// Set emission angle beyond which no data will be read.
+        /**
+         * @param[in] angle Emission angle in degrees.
+         *
+         * @return 0 on success.
+         */
         int emi_ang_limit(double angle);
 
         /// Set sample and line of body center.
@@ -244,12 +249,28 @@ namespace MaRC
         void body_center_line(double);
 
         /// Set latitude and longitude at center of image.
+        /**
+         * @param[in] lat Latitude in degrees at center of image.
+         * @param[in] lon Longitude in degrees at center of image.
+         *
+         * @return 0 on success.
+         */
         int lat_lon_center(double lat, double lon);
 
         /// Set latitude at center of image.
+        /**
+         * @param[in] lat Latitude in degrees at center of image.
+         *
+         * @return 0 on success.
+         */
         int lat_at_center(double lat);
 
         /// Set longitude at center of image.
+        /**
+         * @param[in] lon Longitude in degrees at center of image.
+         *
+         * @return 0 on success.
+         */
         int lon_at_center(double lon);
 
         /// Set the optical axis.
@@ -346,7 +367,13 @@ namespace MaRC
 
     private:
 
-        /// Use range, focal length and scale to compute
+        /// Finalize kilometers per pixel value.
+        /**
+         * Use range, focal length and scale to compute the kilometers
+         * per pixel in the image.
+         *
+         * @return 0 on success.
+         */
         int set_km_per_pixel();
 
         /// Get rotation matrices for case when body centers are given.
@@ -356,6 +383,8 @@ namespace MaRC
          *                         transformation matrix.
          * @param[out] body2observ Body to observer coordinates
          *                         transformation matrix.
+         *
+         * @return 0 on success.
          */
         int rot_matrices(DVector const & range_o,
                          DMatrix & observ2body,

--- a/lib/MaRC/PhotoImage.h
+++ b/lib/MaRC/PhotoImage.h
@@ -321,11 +321,11 @@ namespace MaRC
 
         /// Convert (latitude, longitude) to (sample, sine)
         /**
-         * @param[in] lat  Bodycentric (e.g. planetocentric) latitude
+         * @param[in]  lat Bodycentric (e.g. planetocentric) latitude
          *                 in radians.
-         * @param[in] lon  Longitude in radians.
-         * @param[out] x   Floating point value corresponding to @c i.
-         * @param[out] z   Floating point value corresponding to @c k.
+         * @param[in]  lon Longitude in radians.
+         * @param[out] x   Sample at given latitude and longitude.
+         * @param[out] z   Line at given latitude and longitude.
          *
          * @retval true  Conversion succeeded.
          * @retval false Conversion failed.

--- a/lib/MaRC/PhotoInterpolationStrategy.cpp
+++ b/lib/MaRC/PhotoInterpolationStrategy.cpp
@@ -24,7 +24,6 @@
 #include "PhotoInterpolationStrategy.h"
 
 #include <cmath>
-#include <iostream>
 
 
 MaRC::PhotoInterpolationStrategy::PhotoInterpolationStrategy(

--- a/src/CosPhaseImageFactory.cpp
+++ b/src/CosPhaseImageFactory.cpp
@@ -28,7 +28,7 @@
 
 
 MaRC::CosPhaseImageFactory::CosPhaseImageFactory(
-    std::shared_ptr<OblateSpheroid> body,
+    std::shared_ptr<BodyData> body,
     double sub_observ_lat,
     double sub_observ_lon,
     double sub_solar_lat,

--- a/src/CosPhaseImageFactory.h
+++ b/src/CosPhaseImageFactory.h
@@ -26,13 +26,13 @@
 
 #include "ImageFactory.h"
 
-#include "MaRC/OblateSpheroid.h"
-
 #include <string>
 
 
 namespace MaRC
 {
+    class BodyData;
+
     /**
      * @class CosPhaseImageFactory
      *
@@ -46,9 +46,7 @@ namespace MaRC
 
         /// Constructor.
         /**
-         * @param[in] body           Body being mapped (currently must
-         *                           be represented as an oblate
-         *                           spheroid).
+         * @param[in] body           Body being mapped.
          * @param[in] sub_observ_lat Bodycentric sub-observer latitude
          *                           in degrees.
          * @param[in] sub_observ_lon Sub-observer longitude in
@@ -58,7 +56,7 @@ namespace MaRC
          * @param[in] range          Observer to target center
          *                           distance.
          */
-        CosPhaseImageFactory(std::shared_ptr<OblateSpheroid> body,
+        CosPhaseImageFactory(std::shared_ptr<BodyData> body,
                              double sub_observ_lat,
                              double sub_observ_lon,
                              double sub_solar_lat,
@@ -72,12 +70,7 @@ namespace MaRC
   private:
 
         /// Object representing the body being mapped.
-        /**
-         * @note OblateSpheroid is used instead of BodyData since some
-         *       code in this implementation assumes that the body is
-         *       modeled as an oblate spheroid.
-         */
-        std::shared_ptr<OblateSpheroid> const body_;
+        std::shared_ptr<BodyData> const body_;
 
         /// Sub-Observer Latitude -- BodyCENTRIC (degrees).
         double sub_observ_lat_;

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -57,6 +57,7 @@ noinst_HEADERS = \
   MapCommand.h \
   MapCommand_T.h \
   MapCommand_T.cpp \
+  FITS_memory.h \
   FITS_traits.h \
   calc.h \
   parse_scan.h

--- a/src/MapCommand_T.cpp
+++ b/src/MapCommand_T.cpp
@@ -23,7 +23,8 @@
 #include "MapCommand_T.h"
 #include "FITS_traits.h"
 
-#include <MaRC/config.h>  // For NDEBUG
+#include <MaRC/VirtualImage.h>  // For scale_and_offset()
+#include <MaRC/config.h>        // For NDEBUG
 
 #include <cassert>
 

--- a/src/MosaicImageFactory.cpp
+++ b/src/MosaicImageFactory.cpp
@@ -23,7 +23,6 @@
 #include "MosaicImageFactory.h"
 
 #include <stdexcept>
-#include <iostream>
 
 
 MaRC::MosaicImageFactory::MosaicImageFactory (

--- a/src/Mu0ImageFactory.cpp
+++ b/src/Mu0ImageFactory.cpp
@@ -28,7 +28,7 @@
 
 
 MaRC::Mu0ImageFactory::Mu0ImageFactory(
-    std::shared_ptr<OblateSpheroid> body,
+    std::shared_ptr<BodyData> body,
     double sub_solar_lat,
     double sub_solar_lon)
     : body_(body)

--- a/src/Mu0ImageFactory.h
+++ b/src/Mu0ImageFactory.h
@@ -29,7 +29,7 @@
 
 namespace MaRC
 {
-    class OblateSpheroid;
+    class BodyData;
 
     /**
      * @class Mu0ImageFactory
@@ -44,13 +44,11 @@ namespace MaRC
 
         /// Constructor.
         /**
-         * @param[in] body          Body being mapped (currently must
-         *                          be represented as an oblate
-         *                          spheroid).
+         * @param[in] body          Body being mapped.
          * @param[in] sub_solar_lat Sub-solar latitude in degrees.
          * @param[in] sub_solar_lon Sub-solar longitude in degrees.
          */
-        Mu0ImageFactory(std::shared_ptr<OblateSpheroid> body,
+        Mu0ImageFactory(std::shared_ptr<BodyData> body,
                         double sub_solar_lat,
                         double sub_solar_lon);
 
@@ -61,12 +59,7 @@ namespace MaRC
     private:
 
         /// Object representing the body being mapped.
-        /**
-         * @note OblateSpheroid is used instead of BodyData since some
-         *       code in this implementation assumes that the body is
-         *       modeled as an oblate spheroid.
-         */
-        std::shared_ptr<OblateSpheroid> const body_;
+        std::shared_ptr<BodyData> const body_;
 
         /// Sub-solar latitude (degrees).
         double sub_solar_lat_;

--- a/src/MuImageFactory.cpp
+++ b/src/MuImageFactory.cpp
@@ -27,7 +27,7 @@
 #include <stdexcept>
 
 
-MaRC::MuImageFactory::MuImageFactory(std::shared_ptr<OblateSpheroid> body,
+MaRC::MuImageFactory::MuImageFactory(std::shared_ptr<BodyData> body,
                                      double sub_observ_lat,
                                      double sub_observ_lon,
                                      double range)

--- a/src/MuImageFactory.h
+++ b/src/MuImageFactory.h
@@ -29,7 +29,7 @@
 
 namespace MaRC
 {
-    class OblateSpheroid;
+    class BodyData;
 
     /**
      * @class MuImageFactory
@@ -44,9 +44,7 @@ namespace MaRC
 
         /// Constructor.
         /**
-         * @param[in] body           Body being mapped (currently must
-         *                           be represented as an oblate
-         *                           spheroid).
+         * @param[in] body           Body being mapped.
          * @param[in] sub_observ_lat Bodycentric sub-observer latitude
          *                           in degrees.
          * @param[in] sub_observ_lon Sub-observer longitude in
@@ -54,7 +52,7 @@ namespace MaRC
          * @param[in] range          Observer to target center
          *                           distance.
          */
-        MuImageFactory(std::shared_ptr<OblateSpheroid> body,
+        MuImageFactory(std::shared_ptr<BodyData> body,
                        double sub_observ_lat,
                        double sub_observ_lon,
                        double range);
@@ -66,12 +64,7 @@ namespace MaRC
     private:
 
         /// Object representing the body being mapped.
-        /**
-         * @note OblateSpheroid is used instead of BodyData since some
-         *       code in this implementation assumes that the body is
-         *       modeled as an oblate spheroid.
-         */
-        std::shared_ptr<OblateSpheroid> const body_;
+        std::shared_ptr<BodyData> const body_;
 
         /// Sub-Observer Latitude -- BodyCENTRIC (degrees).
         double sub_observ_lat_;

--- a/src/parse.yy
+++ b/src/parse.yy
@@ -36,15 +36,6 @@
 #include "LatitudeImageFactory.h"
 #include "LongitudeImageFactory.h"
 
-  // SourceImage strategies
-#include <MaRC/PhotoImage.h>
-#include <MaRC/MosaicImage.h>
-#include <MaRC/MuImage.h>
-#include <MaRC/Mu0Image.h>
-#include <MaRC/CosPhaseImage.h>
-#include <MaRC/LatitudeImage.h>
-#include <MaRC/LongitudeImage.h>
-
   // Geometric correction strategies
 #include <MaRC/NullGeometricCorrection.h>
 #include <MaRC/GLLGeometricCorrection.h>
@@ -59,7 +50,6 @@
 #include <MaRC/PolarStereographic.h>
 #include <MaRC/SimpleCylindrical.h>
 
-
 #include <MaRC/Constants.h>
 
 #include "parse_scan.h"
@@ -72,7 +62,7 @@
 #include <memory>
 #include <cstring>
 #include <cmath>
-#include <cassert>
+
 
     std::string map_filename;
 

--- a/tests/Geometry_Test.cpp
+++ b/tests/Geometry_Test.cpp
@@ -29,7 +29,7 @@ namespace
 {
     // "Units in the last place" for floating point equality
     // comparison.
-    constexpr int ulps = 2;
+    constexpr int ulps = 4;
 
     // Arbitrary angle through which coordinate system rotations will
     // be performed.

--- a/tests/Geometry_Test.cpp
+++ b/tests/Geometry_Test.cpp
@@ -23,7 +23,6 @@
 #include <MaRC/Constants.h>
 
 #include<algorithm>
-#include <iostream>
 
 
 namespace

--- a/tests/Geometry_Test.cpp
+++ b/tests/Geometry_Test.cpp
@@ -1,0 +1,99 @@
+/**
+ * @file Geometry_Test.cpp
+ *
+ * Copyright (C) 2017 Ossama Othman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * by the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <MaRC/Geometry.h>
+#include <MaRC/Mathematics.h>
+
+#include <iostream>
+
+namespace
+{
+    // "Units in the last place" for floating point equality
+    // comparison.
+    constexpr int ulps = 2;
+}
+
+bool test_vector_rotation()
+{
+    MaRC::DVector const v{ 3, 4, 5 };
+    MaRC::DVector vr;
+
+    constexpr double angle = 30;
+
+    MaRC::Geometry::RotX(angle, v, vr);
+
+
+    MaRC::Geometry::RotY(angle, v, vr);
+
+
+    MaRC::Geometry::RotZ(angle, v, vr);
+
+
+    return true;
+}
+
+bool test_transformation_matrices()
+{
+    constexpr double angle = 30;
+
+    DMatrix xr = MaRC::Geometry::RotXMatrix(angle);
+    DMatrix yr = MaRC::Geometry::RotYMatrix(angle);
+    DMatrix zr = MaRC::Geometry::RotZMatrix(angle);
+
+    return true;
+}
+
+bool test_vector_magnitude()
+{
+    MaRC::DVector const v{ 3, 4, 5 };
+
+    double const mag =
+        std::sqrt(v[0] * v[0] + v[1] * v[1] + v[2] * v[2]);
+
+    return MaRC::almost_equal(MaRC::Geometry::Magnitude(v),
+                              mag,
+                              ulps);
+}
+
+bool test_unit_vector()
+{
+    MaRC::DVector v{ 3, 4, 5 };
+    MaRC::Geometry::toUnitVector(v);
+
+    constexpr double mag = 1;  // Unit vector magnitude is always 1.
+
+    return
+           std::abs(v[0]) <= 1
+        && std::abs(v[1]) <= 1
+        && std::abs(v[2]) <= 1
+        && MaRC::almost_equal(MaRC::Geometry::Magnitude(v),
+                              mag,
+                              ulps);
+}
+
+int main()
+{
+    return
+        test_vector_rotation()
+        && test_transformation_matrices()
+        && test_vector_magnitude()
+        && test_unit_vector()
+        ? 0 : -1;
+}

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -23,7 +23,8 @@ AM_CPPFLAGS = -I$(top_srcdir)/lib
 check_PROGRAMS = \
   Math_Test   \
   Vector_Test \
-  Matrix_Test
+  Matrix_Test \
+  OblateSpheroid_Test
 
 dist_check_SCRIPTS = MaRC_Prog_Test.sh
 
@@ -36,6 +37,9 @@ Math_Test_SOURCES = Math_Test.cpp
 Vector_Test_SOURCES = Vector_Test.cpp
 
 Matrix_Test_SOURCES = Matrix_Test.cpp
+
+OblateSpheroid_Test_SOURCES = OblateSpheroid_Test.cpp
+OblateSpheroid_Test_LDADD = $(top_builddir)/lib/MaRC/libMaRC.la
 
 TESTS = \
   $(check_PROGRAMS) \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -20,10 +20,11 @@ MARC_LIB = $(top_builddir)/lib/MaRC/libMaRC.la
 
 AM_CPPFLAGS = -I$(top_srcdir)/lib
 
-check_PROGRAMS = \
-  Math_Test   \
-  Vector_Test \
-  Matrix_Test \
+check_PROGRAMS =      \
+  Math_Test           \
+  Vector_Test         \
+  Matrix_Test         \
+  Geometry_Test       \
   OblateSpheroid_Test
 
 dist_check_SCRIPTS = MaRC_Prog_Test.sh
@@ -37,6 +38,9 @@ Math_Test_SOURCES = Math_Test.cpp
 Vector_Test_SOURCES = Vector_Test.cpp
 
 Matrix_Test_SOURCES = Matrix_Test.cpp
+
+Geometry_Test_SOURCES = Geometry_Test.cpp
+Geometry_Test_LDADD = $(top_builddir)/lib/MaRC/libMaRC.la
 
 OblateSpheroid_Test_SOURCES = OblateSpheroid_Test.cpp
 OblateSpheroid_Test_LDADD = $(top_builddir)/lib/MaRC/libMaRC.la

--- a/tests/Math_Test.cpp
+++ b/tests/Math_Test.cpp
@@ -1,4 +1,6 @@
 /**
+ * @file Math_Test.cpp
+ *
  * Copyright (C) 2017 Ossama Othman
  *
  * This program is free software; you can redistribute it and/or modify

--- a/tests/Matrix_Test.cpp
+++ b/tests/Matrix_Test.cpp
@@ -1,4 +1,6 @@
 /**
+ * @file Matrix_Test.cpp
+ *
  * Copyright (C) 2017 Ossama Othman
  *
  * This program is free software; you can redistribute it and/or modify

--- a/tests/Matrix_Test.cpp
+++ b/tests/Matrix_Test.cpp
@@ -18,11 +18,10 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include <iostream>
-#include <algorithm>
-
 #include <MaRC/Vector.h>
 #include <MaRC/Matrix.h>
+
+#include <algorithm>
 
 
 bool test_matrix_initialization()

--- a/tests/OblateSpheroid_Test.cpp
+++ b/tests/OblateSpheroid_Test.cpp
@@ -1,0 +1,153 @@
+/**
+ * @file OblateSpheroid_Test.cpp
+ *
+ * Copyright (C) 2017 Ossama Othman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * by the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <MaRC/OblateSpheroid.h>
+#include <MaRC/Mathematics.h>
+#include <MaRC/Constants.h>
+
+#include <memory>
+#include <cmath>
+
+
+namespace
+{
+    // Jupiter
+    constexpr bool prograde = true;        // Prograde rotation
+    constexpr double a      = 71492;       // Equatorial radius
+    constexpr double c      = 66854;       // Polar radius
+    constexpr double f      = (a - c) / a; // Flattening
+
+    // "Units in the last place" for floating point equality
+    // comparison.
+    constexpr int ulps = 2;
+}
+
+bool test_initialization()
+{
+    static_assert (a >= c,
+                   "Test equatorial radius less than polar radius");
+
+    // Equatorial and polar radii given.
+    auto o1 =
+        std::make_unique<MaRC::OblateSpheroid>(prograde,
+                                               a,
+                                               c,
+                                               -1 /* flattening*/);
+
+    // Equatorial radius and flattening given.
+    auto o2 =
+        std::make_unique<MaRC::OblateSpheroid>(prograde,
+                                               a,
+                                               -1,  // polar radius
+                                               f);
+
+    // Polar radius and flattening given.
+    auto o3 =
+        std::make_unique<MaRC::OblateSpheroid>(prograde,
+                                               -1,  // equatorial radius
+                                               c,
+                                               f);
+
+    constexpr int ulps = 2;
+
+    return
+        prograde == o1->prograde()
+
+        && MaRC::almost_equal(a, o1->eq_rad(),     ulps)
+        && MaRC::almost_equal(c, o1->pol_rad(),    ulps)
+        && MaRC::almost_equal(f, o1->flattening(), ulps)
+
+        && MaRC::almost_equal(a, o2->eq_rad(),     ulps)
+        && MaRC::almost_equal(c, o2->pol_rad(),    ulps)
+        && MaRC::almost_equal(f, o2->flattening(), ulps)
+
+        && MaRC::almost_equal(a, o3->eq_rad(),     ulps)
+        && MaRC::almost_equal(c, o3->pol_rad(),    ulps)
+        && MaRC::almost_equal(f, o3->flattening(), ulps);
+}
+
+bool test_centric_radius()
+{
+    auto o =
+        std::make_unique<MaRC::OblateSpheroid>(prograde,
+                                               a,
+                                               c,
+                                               -1 /* flattening*/);
+
+    constexpr double equator    =  0;               // radians
+    constexpr double north_pole =  90 * C::degree;  //  pi/2
+    constexpr double south_pole = -90 * C::degree;  // -pi/2
+    constexpr double latitude   =  73 * C::degree;  // arbitrary
+
+    double const r = o->centric_radius(latitude);
+
+    // Parametric equation for an oblate spheroid disregarding the
+    // 'y' component.
+    double const x = r * std::cos(latitude);
+    double const y = 0;
+    double const z = r * std::sin(latitude);
+
+    return
+        // Centric radius, e.g. planetocentric, is the same as the
+        // equatorial radius at the equator (latitude 0).
+            MaRC::almost_equal(a, o->centric_radius(equator),    ulps)
+        && !MaRC::almost_equal(a, o->centric_radius(north_pole), ulps)
+        && !MaRC::almost_equal(a, o->centric_radius(south_pole), ulps)
+
+        // Centric radius is the same as the polar radius at the poles
+        // (latitudes -90 and 90).
+        &&  MaRC::almost_equal(c, o->centric_radius(north_pole), ulps)
+        &&  MaRC::almost_equal(c, o->centric_radius(south_pole), ulps)
+        && !MaRC::almost_equal(c, o->centric_radius(equator),    ulps)
+
+        && r < a
+        && r > c
+
+        /*
+          Cartesian equation for an oblate spheroid.
+
+           2    2    2
+          x  + y    z
+          ------- + -- = 1
+             2       2
+            a       c
+        */
+
+        && MaRC::almost_equal((x * x + y * y) / (a * a)
+                              + (z * z) / (c * c), 1.0, ulps);
+}
+
+bool test_latitudes()
+{
+    /**
+     * @todo Test centric_latitude() and graphic_latitude() members.
+     */
+
+    return true;
+}
+
+int main()
+{
+    return
+        test_initialization()
+        && test_centric_radius()
+        && test_latitudes()
+        ? 0 : -1;
+}

--- a/tests/OblateSpheroid_Test.cpp
+++ b/tests/OblateSpheroid_Test.cpp
@@ -94,20 +94,24 @@ bool test_centric_radius()
     constexpr double equator    =  0;               // radians
     constexpr double north_pole =  90 * C::degree;  //  pi/2
     constexpr double south_pole = -90 * C::degree;  // -pi/2
-    constexpr double latitude   =  73 * C::degree;  // arbitrary
+    constexpr double latitude   = -23 * C::degree;  // arbitrary
+    constexpr double longitude  =  0;               // no 'y' component
 
     double const r = o->centric_radius(latitude);
 
-    // Parametric equation for an oblate spheroid disregarding the
-    // 'y' component.
-    double const x = r * std::cos(latitude);
-    double const y = 0;
+    // Parametric equation for a spheroid at longitude zero.
+    double const x = r * std::cos(latitude) * std::cos(longitude);
+    double const y = r * std::cos(latitude) * std::sin(longitude);;
     double const z = r * std::sin(latitude);
 
     return
+        // Oblate spheroid sanity checks.
+           r <= a
+        && r >= c
+
         // Centric radius, e.g. planetocentric, is the same as the
         // equatorial radius at the equator (latitude 0).
-            MaRC::almost_equal(a, o->centric_radius(equator),    ulps)
+        &&  MaRC::almost_equal(a, o->centric_radius(equator),    ulps)
         && !MaRC::almost_equal(a, o->centric_radius(north_pole), ulps)
         && !MaRC::almost_equal(a, o->centric_radius(south_pole), ulps)
 
@@ -117,21 +121,7 @@ bool test_centric_radius()
         &&  MaRC::almost_equal(c, o->centric_radius(south_pole), ulps)
         && !MaRC::almost_equal(c, o->centric_radius(equator),    ulps)
 
-        && r < a
-        && r > c
-
-        /*
-          Cartesian equation for an oblate spheroid.
-
-           2    2    2
-          x  + y    z
-          ------- + -- = 1
-             2       2
-            a       c
-        */
-
-        && MaRC::almost_equal((x * x + y * y) / (a * a)
-                              + (z * z) / (c * c), 1.0, ulps);
+        && MaRC::almost_equal(r, MaRC::hypot(x, y, z), ulps);
 }
 
 bool test_latitudes()
@@ -143,11 +133,41 @@ bool test_latitudes()
     return true;
 }
 
+bool test_mu()
+{
+    /**
+     * @todo Test mu() member.
+     */
+
+    return true;
+}
+
+bool test_mu0()
+{
+    /**
+     * @todo Test mu0() member.
+     */
+
+    return true;
+}
+
+bool test_cos_phase()
+{
+    /**
+     * @todo Test cos_phase() member.
+     */
+
+    return true;
+}
+
 int main()
 {
     return
         test_initialization()
         && test_centric_radius()
         && test_latitudes()
+        && test_mu()
+        && test_mu0()
+        && test_cos_phase()
         ? 0 : -1;
 }

--- a/tests/OblateSpheroid_Test.cpp
+++ b/tests/OblateSpheroid_Test.cpp
@@ -45,27 +45,25 @@ bool test_initialization()
                    "Test equatorial radius less than polar radius");
 
     // Equatorial and polar radii given.
-    auto o1 =
+    auto const o1 =
         std::make_unique<MaRC::OblateSpheroid>(prograde,
                                                a,
                                                c,
                                                -1 /* flattening*/);
 
     // Equatorial radius and flattening given.
-    auto o2 =
+    auto const o2 =
         std::make_unique<MaRC::OblateSpheroid>(prograde,
                                                a,
                                                -1,  // polar radius
                                                f);
 
     // Polar radius and flattening given.
-    auto o3 =
+    auto const o3 =
         std::make_unique<MaRC::OblateSpheroid>(prograde,
                                                -1,  // equatorial radius
                                                c,
                                                f);
-
-    constexpr int ulps = 2;
 
     return
         prograde == o1->prograde()
@@ -85,7 +83,7 @@ bool test_initialization()
 
 bool test_centric_radius()
 {
-    auto o =
+    auto const o =
         std::make_unique<MaRC::OblateSpheroid>(prograde,
                                                a,
                                                c,
@@ -126,17 +124,33 @@ bool test_centric_radius()
 
 bool test_latitudes()
 {
+    auto const o =
+        std::make_unique<MaRC::OblateSpheroid>(prograde,
+                                               a,
+                                               c,
+                                               -1 /* flattening*/);
+
+    constexpr double latc = 27 * C::degree;
+
     /**
-     * @todo Test centric_latitude() and graphic_latitude() members.
+     * @todo Prior to running the below latitude tests, test
+     *       centric_latitude() and graphic_latitude() methods
+     *       independently of each other.
      */
 
-    return true;
+    double const latg = o->graphic_latitude(latc);
+
+    return
+        !MaRC::almost_equal(latc, latg, ulps)
+        && MaRC::almost_equal(latc,
+                              o->centric_latitude(latg),
+                              ulps);
 }
 
 bool test_mu()
 {
     /**
-     * @todo Test mu() member.
+     * @todo Test @c OblateSpheroid::mu() method.
      */
 
     return true;
@@ -145,7 +159,7 @@ bool test_mu()
 bool test_mu0()
 {
     /**
-     * @todo Test mu0() member.
+     * @todo Test @c OblateSpheroid::mu0() method.
      */
 
     return true;
@@ -154,7 +168,7 @@ bool test_mu0()
 bool test_cos_phase()
 {
     /**
-     * @todo Test cos_phase() member.
+     * @todo Test @c OblateSpheroid::cos_phase() method.
      */
 
     return true;

--- a/tests/OblateSpheroid_Test.cpp
+++ b/tests/OblateSpheroid_Test.cpp
@@ -153,6 +153,15 @@ bool test_mu()
      * @todo Test @c OblateSpheroid::mu() method.
      */
 
+    auto const o =
+        std::make_unique<MaRC::OblateSpheroid>(prograde,
+                                               a,
+                                               c,
+                                               -1 /* flattening*/);
+
+    constexpr double sub_observ_lat = 42  * C::degree;
+    constexpr double sub_observ_lon = 247 * C::degree;
+
     return true;
 }
 

--- a/tests/Vector_Test.cpp
+++ b/tests/Vector_Test.cpp
@@ -1,4 +1,6 @@
 /**
+ * @file Vector_Test.cpp
+ *
  * Copyright (C) 2017 Ossama Othman
  *
  * This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
Determine visibility by verifying the emission and incidence (only checked if configured to do so) angles are positive.  Greatly simplifies visibility implementations, and correctly takes into account necessary viewing geometry variables, and removes requirement that the body is modeled as an oblate spheroid.
