### PR TITLE
Reduce use of magic numbers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ src/marc
 test-driver
 tests/*.log
 tests/*.trs
+tests/DefaultConfiguration_Test
 tests/Math_Test
 tests/Vector_Test
 tests/Matrix_Test

--- a/lib/MaRC/DefaultConfiguration.h
+++ b/lib/MaRC/DefaultConfiguration.h
@@ -29,17 +29,79 @@
 namespace MaRC
 {
 
+    /**
+     * @namespace default_configuration
+     *
+     * @brief Default MaRC configuration constants.
+     *
+     * These constants are used throughout MaRC when a corresponding
+     * user-supplied value is not available.
+     */
     namespace default_configuration
     {
 
+        /**
+         * @name Map Latitude Constants
+         */
+        //@{
+        /**
+         * @brief Lowest latitude in degrees to be potentially mapped.
+         *
+         * @note This value should never be less than -90.
+         */
         constexpr double latitude_low   = -90;
+
+        /**
+         * @brief Highest latitude in degrees to be potentially mapped.
+         *
+         * @note This value should never be greater than 90.
+         */
         constexpr double latitude_high  =  90;
+
+        /**
+         * @brief Maximum latitude range in degrees to be potentially
+         *        mapped.
+         *
+         * @note This value should never be greater than 180.
+         */
         constexpr double latitude_range =  latitude_high - latitude_low;
+        //@}
 
+        /**
+         * @name Map Longitude Constants
+         */
+        //@{
+        /**
+         * @brief Lowest longitude in degrees to be potentially mapped.
+         *
+         * @note This value should never be less than -180.
+         */
         constexpr double longitude_low   = 0;
-        constexpr double longitude_high  = 360;
-        constexpr double longitude_range = longitude_high - longitude_low;
 
+        /**
+         * @brief Highest longitude in degrees to be potentially mapped.
+         *
+         * @note This value should never be greater than 360.
+         */
+        constexpr double longitude_high  = 360;
+
+
+        /**
+         * @brief Maximum longitude range in degrees to be potentially
+         *        mapped.
+         *
+         * @note This value should never be greater than 360.
+         */
+        constexpr double longitude_range = longitude_high - longitude_low;
+        //@}
+
+        /**
+         * @name Map Cosine Virtual Image Constants
+         *
+         * @note As these values are cosines, the allowable range is
+         *       [-1, 1].
+         */
+        //@{
         constexpr double mu_low  = -1;
         constexpr double mu_high =  1;
 
@@ -48,6 +110,7 @@ namespace MaRC
 
         constexpr double cos_phase_low  = -1;
         constexpr double cos_phase_high =  1;
+        //@}
 
     }
 

--- a/lib/MaRC/DefaultConfiguration.h
+++ b/lib/MaRC/DefaultConfiguration.h
@@ -1,0 +1,57 @@
+// -*- C++ -*-
+/**
+ * @file DefaultConfiguration.h
+ *
+ * Copyright (C) 2017  Ossama Othman
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301  USA
+ *
+ * @author Ossama Othman
+ */
+
+#ifndef MARC_DEFAULT_CONFIGURATION_H
+#define MARC_DEFAULT_CONFIGURATION_H
+
+
+namespace MaRC
+{
+
+    namespace default_configuration
+    {
+
+        constexpr double latitude_low   = -90;
+        constexpr double latitude_high  =  90;
+        constexpr double latitude_range =  latitude_high - latitude_low;
+
+        constexpr double longitude_low   = 0;
+        constexpr double longitude_high  = 360;
+        constexpr double longitude_range = longitude_high - longitude_low;
+
+        constexpr double mu_low  = -1;
+        constexpr double mu_high =  1;
+
+        constexpr double mu0_low  = -1;
+        constexpr double mu0_high =  1;
+
+        constexpr double cos_phase_low  = -1;
+        constexpr double cos_phase_high =  1;
+
+    }
+
+} // End MaRC namespace
+
+
+#endif  /* MARC_DEFAULT_CONFIGURATION_H */

--- a/lib/MaRC/LongitudeImage.h
+++ b/lib/MaRC/LongitudeImage.h
@@ -2,7 +2,7 @@
 /**
  * @file LongitudeImage.h
  *
- * Copyright (C) 2003-2004, 2017  Ossama Othmanp
+ * Copyright (C) 2003-2004, 2017  Ossama Othman
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/lib/MaRC/Makefile.am
+++ b/lib/MaRC/Makefile.am
@@ -51,6 +51,7 @@ libMaRC_la_SOURCES = \
   Version.cpp
 
 pkginclude_HEADERS = \
+  DefaultConfiguration.h \
   config.h \
   \
   Mathematics.h   \
@@ -92,6 +93,7 @@ pkginclude_HEADERS = \
   PolarStereographic.cpp \
   SimpleCylindrical.h \
   SimpleCylindrical.cpp \
+  Validate.h \
   \
   Constants.h \
   \

--- a/lib/MaRC/MapFactory.h
+++ b/lib/MaRC/MapFactory.h
@@ -103,7 +103,7 @@ namespace MaRC
                                std::size_t lines,
                                float lat_interval,
                                float lon_interval,
-                               grid_type & grid) = 0;
+                               grid_type & grid) const = 0;
 
     };
 
@@ -196,7 +196,7 @@ namespace MaRC
          */
         virtual void plot_map(std::size_t samples,
                               std::size_t lines,
-                              plot_type plot) = 0;
+                              plot_type plot) const = 0;
 
         /// Plot the data on the map.
         /**

--- a/lib/MaRC/Mercator.cpp
+++ b/lib/MaRC/Mercator.cpp
@@ -68,7 +68,7 @@ template <typename T>
 void
 MaRC::Mercator<T>::plot_map(std::size_t samples,
                             std::size_t lines,
-                            plot_type plot)
+                            plot_type plot) const
 {
     std::size_t const nelem = samples * lines;
 
@@ -110,7 +110,7 @@ MaRC::Mercator<T>::plot_grid(std::size_t samples,
                              std::size_t lines,
                              float lat_interval,
                              float lon_interval,
-                             grid_type & grid)
+                             grid_type & grid) const
 {
     // No need to take absolute value.  Always positive.
     double const xmax = static_cast<double>(lines) / samples * C::pi;

--- a/lib/MaRC/Mercator.h
+++ b/lib/MaRC/Mercator.h
@@ -88,7 +88,7 @@ namespace MaRC
          */
         virtual void plot_map(std::size_t samples,
                               std::size_t lines,
-                              plot_type plot);
+                              plot_type plot) const;
 
         /**
          * Create the Mercator map latitude/longitude grid.
@@ -99,7 +99,7 @@ namespace MaRC
                                std::size_t lines,
                                float lat_interval,
                                float lon_interval,
-                               grid_type & grid);
+                               grid_type & grid) const;
 
         /// Orient longitude according to rotation direction
         /// (prograde/retrograde).

--- a/lib/MaRC/Orthographic.cpp
+++ b/lib/MaRC/Orthographic.cpp
@@ -488,7 +488,7 @@ MaRC::Orthographic<T>::map_parameters(std::size_t samples,
     if (this->km_per_pixel_ <= 0) {
         static constexpr double MAP_FRACTION = 0.9;
 
-        // The largest axis of the oblate spheroid will take up at most
+        // The largest axis of the spheroid will take up at most
         // MAP_FRACTION of the smallest dimension of the map.
         km_per_pixel =
             2 * std::max(this->body_->eq_rad(), this->body_->pol_rad())

--- a/lib/MaRC/Orthographic.h
+++ b/lib/MaRC/Orthographic.h
@@ -95,8 +95,26 @@ namespace MaRC
 
     private:
 
-        /// Initialize all attributes.
-        void init (std::size_t samples, std::size_t lines);
+        /// Retrieve map size dependent parameters.
+        /**
+         * Retrieve map parameters that may depend on the map
+         * dimensions.
+         *
+         * @param[in]  samples       Number of samples in the map.
+         * @param[in]  lines         Number of lines in the map.
+         * @param[out] km_per_pixel  The number of kilometers per
+         *                           pixel in the orthographic
+         *                           projection.
+         * @param[out] sample_center Body center sample in projection
+         *                           (measured from left edge).
+         * @param[out] line_center   Body center line in projection
+         *                           (measured from bottom edge).
+         */
+        void map_parameters(std::size_t samples,
+                            std::size_t lines,
+                            double & km_per_pixel,
+                            double & sample_center,
+                            double & line_center) const;
 
         /**
          * Create the Orthographic map projection.
@@ -105,7 +123,7 @@ namespace MaRC
          */
         virtual void plot_map(std::size_t samples,
                               std::size_t lines,
-                              plot_type plot);
+                              plot_type plot) const;
 
         /**
          * Create the Orthographic map latitude/longitude grid.
@@ -116,7 +134,7 @@ namespace MaRC
                                std::size_t lines,
                                float lat_interval,
                                float lon_interval,
-                               grid_type & grid);
+                               grid_type & grid) const;
 
     private:
 
@@ -136,13 +154,16 @@ namespace MaRC
         /// projection.
         double km_per_pixel_;
 
-        /// Body center sample in projection (measured from left edge).
+        /// Body center sample in projection (measured from left
+        /// edge).
         double sample_center_;
 
-        /// Body center line in projection (measured from bottom edge).
+        /// Body center line in projection (measured from bottom
+        /// edge).
         double line_center_;
 
-        /// Latitude at center of projection (measured from left edge).
+        /// Latitude at center of projection (measured from left
+        /// edge).
         double lat_at_center_;
 
         /// Line center of projection (measured from bottom edge).

--- a/lib/MaRC/PolarStereographic.cpp
+++ b/lib/MaRC/PolarStereographic.cpp
@@ -79,7 +79,7 @@ template <typename T>
 void
 MaRC::PolarStereographic<T>::plot_map(std::size_t samples,
                                       std::size_t lines,
-                                      plot_type plot)
+                                      plot_type plot) const
 {
     std::size_t const nelem = samples * lines;
 
@@ -140,7 +140,7 @@ MaRC::PolarStereographic<T>::plot_grid(std::size_t samples,
                                        std::size_t lines,
                                        float lat_interval,
                                        float lon_interval,
-                                       grid_type & grid)
+                                       grid_type & grid) const
 {
     static constexpr std::size_t imax = 2000;
 

--- a/lib/MaRC/PolarStereographic.h
+++ b/lib/MaRC/PolarStereographic.h
@@ -92,7 +92,7 @@ namespace MaRC
          */
         virtual void plot_map(std::size_t samples,
                               std::size_t lines,
-                              plot_type plot);
+                              plot_type plot) const;
 
         /**
          * Create the Polar Stereographic map latitude/longitude
@@ -104,7 +104,7 @@ namespace MaRC
                                std::size_t lines,
                                float lat_interval,
                                float lon_interval,
-                               grid_type & grid);
+                               grid_type & grid) const;
 
         /// The underlying Polar Stereographic projection equation.
         /**

--- a/lib/MaRC/SimpleCylindrical.cpp
+++ b/lib/MaRC/SimpleCylindrical.cpp
@@ -78,7 +78,7 @@ template <typename T>
 void
 MaRC::SimpleCylindrical<T>::plot_map(std::size_t samples,
                                      std::size_t lines,
-                                     plot_type plot)
+                                     plot_type plot) const
 {
     // Conversion factor -- latitudes per line
     double const cf = (this->hi_lat_ - this->lo_lat_) / lines;
@@ -112,7 +112,7 @@ MaRC::SimpleCylindrical<T>::plot_grid(std::size_t samples,
                                       std::size_t lines,
                                       float lat_interval,
                                       float lon_interval,
-                                      grid_type & grid)
+                                      grid_type & grid) const
 {
     // Convert back to degrees
     double const lo_lat = this->lo_lat_ / C::degree;

--- a/lib/MaRC/SimpleCylindrical.cpp
+++ b/lib/MaRC/SimpleCylindrical.cpp
@@ -24,6 +24,7 @@
 #include "MaRC/SimpleCylindrical.h"
 #include "MaRC/Constants.h"
 #include "MaRC/BodyData.h"
+#include "MaRC/Validate.h"
 
 #include <limits>
 #include <cmath>
@@ -40,33 +41,21 @@ MaRC::SimpleCylindrical<T>::SimpleCylindrical(
     bool graphic_lat)
     : MapFactory<T>()
     , body_(body)
-    , lo_lat_(C::pi_2)
-    , hi_lat_(-C::pi_2)
-    , lo_lon_(0)
-    , hi_lon_(C::_2pi)
+    , lo_lat_(MaRC::validate_latitude(lo_lat))
+    , hi_lat_(MaRC::validate_latitude(hi_lat))
+    , lo_lon_(MaRC::validate_longitude(lo_lon))
+    , hi_lon_(MaRC::validate_longitude(hi_lon))
     , graphic_lat_(graphic_lat)
 {
-    // Set latitude range.
     // All latitudes are fed to SimpleCylindrical as CENTRIC.
-    if (lo_lat >= -90 && lo_lat <= 90)
-        this->lo_lat_ = lo_lat * C::degree;
-
-    if (hi_lat >= -90 && hi_lat <= 90)
-        this->hi_lat_ = hi_lat * C::degree;
-
     // Convert to GRAPHIC latitude if requested.
     if (graphic_lat) {
         this->lo_lat_ = this->body_->graphic_latitude(this->lo_lat_);
         this->hi_lat_ = this->body_->graphic_latitude(this->hi_lat_);
     }
 
-    // Set longitude range
-    if (lo_lon >= -360 && lo_lon <= 360)
-        this->lo_lon_ = lo_lon * C::degree;
-
-    if (hi_lon >= -360 && hi_lon <= 360)
-        this->hi_lon_ = hi_lon * C::degree;
-
+    // Set lower longitude to equivalent longitude less than upper
+    // longitude to make sure longitude range is computed correctly.
     if (this->lo_lon_ > this->hi_lon_)
         this->lo_lon_ -= C::_2pi;
 }

--- a/lib/MaRC/SimpleCylindrical.h
+++ b/lib/MaRC/SimpleCylindrical.h
@@ -99,7 +99,7 @@ namespace MaRC
          */
         virtual void plot_map(std::size_t samples,
                               std::size_t lines,
-                              plot_type plot);
+                              plot_type plot) const;
 
         /**
          * Create the Simple Cylindrical map latitude/longitude grid.
@@ -110,7 +110,7 @@ namespace MaRC
                                std::size_t lines,
                                float lat_interval,
                                float lon_interval,
-                               grid_type & grid);
+                               grid_type & grid) const;
 
         /// Orient longitude according to rotation direction
         /// (prograde/retrograde).

--- a/lib/MaRC/SimpleCylindrical.h
+++ b/lib/MaRC/SimpleCylindrical.h
@@ -58,13 +58,13 @@ namespace MaRC
         /**
          * @param[in] body        Pointer to BodyData object
          *                        representing body being mapped.
-         * @param[in] lo_lat      Lower latitude  in simple
+         * @param[in] lo_lat      Bodycentric lower latitude in
+         *                        degrees in simple cylindrical map.
+         * @param[in] hi_lat      Bodycentric upper latitude in
+         *                        degrees in simple cylindrical map.
+         * @param[in] lo_lon      Lower longitude in degrees in simple
          *                        cylindrical map.
-         * @param[in] hi_lat      Upper latitude  in simple
-         *                        cylindrical map.
-         * @param[in] lo_lon      Lower longitude in simple
-         *                        cylindrical map.
-         * @param[in] hi_lon      Upper longitude in simple
+         * @param[in] hi_lon      Upper longitude in degrees in simple
          *                        cylindrical map.
          * @param[in] graphic_lat Map bodygraphic latitudes instead of
          *                        bodycentric latitudes.

--- a/lib/MaRC/Validate.h
+++ b/lib/MaRC/Validate.h
@@ -1,0 +1,71 @@
+// -*- C++ -*-
+/**
+ * @file Validate.h
+ *
+ * Copyright (C) 2017  Ossama Othman
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301  USA
+ *
+ * @author Ossama Othman
+ */
+
+#ifndef MARC_VALIDATE_H
+#define MARC_VALIDATE_H
+
+
+namespace MaRC
+{
+
+    /**
+     * @brief Validate and return latitude in radians.
+     *
+     * Make sure the given latitude @a lat falls within the range of
+     * valid latitudes, i.e. [-90, 90].
+     *
+     * @param[in] lat Latitude in degrees.
+     *
+     * @return Latitude in radians.
+     */
+    double validate_latitude(double lat)
+    {
+        if (lat < -90 || lat > 90)
+            throw std::range_error("Invalid latitude.");
+
+        return lat * C::degree;
+    }
+
+    /**
+     * @brief Validate and return longitude in radians.
+     *
+     * Make sure the given longitude @a lon falls within the range of
+     * valid longitudes, i.e. [-360, 360].
+     *
+     * @param[in] lat Latitude in degrees.
+     *
+     * @return Latitude in radians.
+     */
+    double validate_longitude(double lon)
+    {
+        if (lon < -360 || lon > 360)
+            throw std::range_error("Invalid longitude.");
+
+        return lon * C::degree;
+    }
+
+} // End MaRC namespace
+
+
+#endif  /* MARC_VALIDATE_H */

--- a/lib/MaRC/Validate.h
+++ b/lib/MaRC/Validate.h
@@ -25,6 +25,10 @@
 #ifndef MARC_VALIDATE_H
 #define MARC_VALIDATE_H
 
+#include "MaRC/Constants.h"
+
+#include <stdexcept>
+
 
 namespace MaRC
 {

--- a/lib/MaRC/root_find.h
+++ b/lib/MaRC/root_find.h
@@ -44,7 +44,7 @@ namespace MaRC
                double ordinate_guess,
                double abscissa_guess,
                double (MAP_FACTORY::* equation)(double) const,
-               MAP_FACTORY * map)
+               MAP_FACTORY const * map)
     {
         double const tolerance = 1e-4;
         double const delta = 1e-3;

--- a/src/CosPhaseImageFactory.cpp
+++ b/src/CosPhaseImageFactory.cpp
@@ -23,6 +23,7 @@
 #include "CosPhaseImageFactory.h"
 
 #include "MaRC/CosPhaseImage.h"
+#include "MaRC/DefaultConfiguration.h"
 
 #include <stdexcept>
 
@@ -46,12 +47,12 @@ MaRC::CosPhaseImageFactory::CosPhaseImageFactory(
 std::unique_ptr<MaRC::SourceImage>
 MaRC::CosPhaseImageFactory::make(scale_offset_functor calc_so)
 {
-    constexpr double cos_phase_min = -1;
-    constexpr double cos_phase_max =  1;
+    using namespace MaRC::default_configuration;
+
     double scale;
     double offset;
 
-    if (!calc_so(cos_phase_min, cos_phase_max, scale, offset)) {
+    if (!calc_so(cos_phase_low, cos_phase_high, scale, offset)) {
         throw std::range_error("Cannot store cosine of phase angles in "
                                "map of chosen datatype.");
     }

--- a/src/LatitudeImageFactory.cpp
+++ b/src/LatitudeImageFactory.cpp
@@ -23,6 +23,7 @@
 #include "LatitudeImageFactory.h"
 
 #include "MaRC/LatitudeImage.h"
+#include "MaRC/DefaultConfiguration.h"
 
 #include <stdexcept>
 
@@ -38,12 +39,12 @@ MaRC::LatitudeImageFactory::LatitudeImageFactory(
 std::unique_ptr<MaRC::SourceImage>
 MaRC::LatitudeImageFactory::make(scale_offset_functor calc_so)
 {
-    constexpr double lat_min = -90;
-    constexpr double lat_max =  90;
+    using namespace MaRC::default_configuration;
+
     double scale;
     double offset;
 
-    if (!calc_so(lat_min, lat_max, scale, offset)) {
+    if (!calc_so(latitude_low, latitude_high, scale, offset)) {
         throw std::range_error("Cannot store latitudes in map of "
                                "chosen data type.");
     }

--- a/src/LongitudeImageFactory.cpp
+++ b/src/LongitudeImageFactory.cpp
@@ -23,6 +23,7 @@
 #include "LongitudeImageFactory.h"
 
 #include "MaRC/LongitudeImage.h"
+#include "MaRC/DefaultConfiguration.h"
 
 #include <stdexcept>
 
@@ -30,8 +31,8 @@
 std::unique_ptr<MaRC::SourceImage>
 MaRC::LongitudeImageFactory::make(scale_offset_functor calc_so)
 {
-    constexpr double lon_min = 0;
-    constexpr double lon_max = 360;
+    using namespace MaRC::default_configuration;
+
     double scale;
     double offset;
 
@@ -41,7 +42,7 @@ MaRC::LongitudeImageFactory::make(scale_offset_functor calc_so)
      *       @c std::unique_ptr<MaRC::SourceImage> instead?  The same
      *       go for the other @c VirtualImage factory implementations.
      */
-    if (!calc_so(lon_min, lon_max, scale, offset)) {
+    if (!calc_so(longitude_low, longitude_high, scale, offset)) {
         throw std::range_error("Cannot store longitudes in map of "
                                "chosen data type.");
     }

--- a/src/Mu0ImageFactory.cpp
+++ b/src/Mu0ImageFactory.cpp
@@ -23,6 +23,7 @@
 #include "Mu0ImageFactory.h"
 
 #include "MaRC/Mu0Image.h"
+#include "MaRC/DefaultConfiguration.h"
 
 #include <stdexcept>
 
@@ -40,12 +41,12 @@ MaRC::Mu0ImageFactory::Mu0ImageFactory(
 std::unique_ptr<MaRC::SourceImage>
 MaRC::Mu0ImageFactory::make(scale_offset_functor calc_so)
 {
-    constexpr double mu0_min = -1;
-    constexpr double mu0_max =  1;
+    using namespace MaRC::default_configuration;
+
     double scale;
     double offset;
 
-    if (!calc_so(mu0_min, mu0_max, scale, offset)) {
+    if (!calc_so(mu0_low, mu0_high, scale, offset)) {
         throw std::range_error("Cannot store mu0 (cosines) in map of "
                                "chosen data type.");
     }

--- a/src/MuImageFactory.cpp
+++ b/src/MuImageFactory.cpp
@@ -23,6 +23,7 @@
 #include "MuImageFactory.h"
 
 #include "MaRC/MuImage.h"
+#include "MaRC/DefaultConfiguration.h"
 
 #include <stdexcept>
 
@@ -41,12 +42,12 @@ MaRC::MuImageFactory::MuImageFactory(std::shared_ptr<BodyData> body,
 std::unique_ptr<MaRC::SourceImage>
 MaRC::MuImageFactory::make(scale_offset_functor calc_so)
 {
-    constexpr double mu_min = -1;
-    constexpr double mu_max =  1;
+    using namespace MaRC::default_configuration;
+
     double scale;
     double offset;
 
-    if (!calc_so(mu_min, mu_max, scale, offset)) {
+    if (!calc_so(mu_low, mu_high, scale, offset)) {
         throw std::range_error("Cannot store mu (cosines) in map of "
                                "chosen data type.");
     }

--- a/src/parse.yy
+++ b/src/parse.yy
@@ -51,6 +51,7 @@
 #include <MaRC/SimpleCylindrical.h>
 
 #include <MaRC/Constants.h>
+#include "MaRC/DefaultConfiguration.h"
 
 #include "parse_scan.h"
 #include "calc.h"
@@ -132,10 +133,10 @@
     double minimum = std::numeric_limits<double>::quiet_NaN();
     double maximum = std::numeric_limits<double>::quiet_NaN();
 
-    std::size_t nibble_left_val;
-    std::size_t nibble_right_val;
-    std::size_t nibble_top_val;
-    std::size_t nibble_bottom_val;
+    std::size_t nibble_left_val   = 0;
+    std::size_t nibble_right_val  = 0;
+    std::size_t nibble_top_val    = 0;
+    std::size_t nibble_bottom_val = 0;
 
     double sample_center = std::numeric_limits<double>::quiet_NaN();
     double line_center   = std::numeric_limits<double>::quiet_NaN();
@@ -155,10 +156,10 @@
     double max_lat = std::numeric_limits<double>::quiet_NaN();
 
     // Simple Cylindrical projection options
-    double lo_lat = -90;
-    double hi_lat = 90;
-    double lo_lon = 0;
-    double hi_lon = 360;
+    double lo_lat = MaRC::default_configuration::latitude_low;
+    double hi_lat = MaRC::default_configuration::latitude_high;
+    double lo_lon = MaRC::default_configuration::longitude_low;
+    double hi_lon = MaRC::default_configuration::longitude_high;
 
     // Orthographic and Perspective projection options
 
@@ -1983,7 +1984,7 @@ latitude:
         | latitude_sub 'C'      { $$ = $1; }
         | latitude_sub 'G'      {
             /* Convert to CENTRIC latitude. */
-            $$ = oblate_spheroid->centric_latitude ($1 * C::degree)
+            $$ = oblate_spheroid->centric_latitude($1 * C::degree)
                    / C::degree; }
 ;
 

--- a/tests/DefaultConfiguration_Test.cpp
+++ b/tests/DefaultConfiguration_Test.cpp
@@ -1,0 +1,77 @@
+/**
+ * @file Default_Configuration_Test.cpp
+ *
+ * Copyright (C) 2017 Ossama Othman
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * by the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <MaRC/DefaultConfiguration.h>
+#include <MaRC/Mathematics.h>
+
+/**
+ * @todo The built-in @c operator<=() and operator>=() for floating
+ *       point may not be suitable to check for equality due to
+ *       limitations in floating point types themselves.  We may want
+ *       to use something like MaRC::almost_equal() instead.
+ */
+
+bool test_latitude_configuration()
+{
+    using namespace MaRC::default_configuration;
+
+    // Largest latitude range that is valid is [-90, 90].
+
+    return latitude_low   >= -90
+        && latitude_high  <=  90
+        && latitude_range <=  180;
+}
+
+bool test_longitude_configuration()
+{
+    using namespace MaRC::default_configuration;
+
+    // Largest longitude ranges that are valid are [-180, 180] and
+    // [0, 360].
+
+    return longitude_low   >= -180
+        && longitude_high  <=  360
+        && longitude_range <=  360;
+}
+
+bool test_cosine_configuration()
+{
+    using namespace MaRC::default_configuration;
+
+    // Largest cosine range that is valid is [-1, 1].
+
+    return mu_low   >= -1
+        && mu_high  <=  1
+
+        && mu0_low   >= -1
+        && mu0_high  <=  1
+
+        && cos_phase_low   >= -1
+        && cos_phase_high  <=  1;
+}
+
+int main()
+{
+    return
+        test_latitude_configuration()
+        && test_longitude_configuration()
+        && test_cosine_configuration()
+        ? 0 : -1;
+}

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -20,12 +20,13 @@ MARC_LIB = $(top_builddir)/lib/MaRC/libMaRC.la
 
 AM_CPPFLAGS = -I$(top_srcdir)/lib
 
-check_PROGRAMS =      \
-  Math_Test           \
-  Vector_Test         \
-  Matrix_Test         \
-  Geometry_Test       \
-  OblateSpheroid_Test \
+check_PROGRAMS =            \
+  DefaultConfiguration_Test \
+  Math_Test                 \
+  Vector_Test               \
+  Matrix_Test               \
+  Geometry_Test             \
+  OblateSpheroid_Test       \
   Scale_Offset_Test
 
 dist_check_SCRIPTS = MaRC_Prog_Test.sh
@@ -33,6 +34,8 @@ dist_check_SCRIPTS = MaRC_Prog_Test.sh
 dist_check_DATA = \
   test_map.inp \
   test.fits.gz
+
+DefaultConfiguration_Test_SOURCES = DefaultConfiguration_Test.cpp
 
 Math_Test_SOURCES = Math_Test.cpp
 

--- a/tests/Scale_Offset_Test.cpp
+++ b/tests/Scale_Offset_Test.cpp
@@ -19,6 +19,7 @@
  */
 
 #include <MaRC/VirtualImage.h>
+#include <MaRC/DefaultConfiguration.h>
 
 #include <limits>
 #include <cstdint>
@@ -55,19 +56,19 @@ bool test_cosine_scaling()
 template <typename T>
 bool test_latitude_scaling()
 {
-    // Latitude range is [-90, 90].
-    constexpr double minimum = -90;
-    constexpr double maximum =  90;
+    using namespace MaRC::default_configuration;
 
-    return test_scaling<T>(minimum, maximum);
+    // Latitude range is [-90, 90] by default.
+
+    return test_scaling<T>(latitude_low, latitude_high);
 }
 
 template <typename T>
 bool test_longitude_scaling()
 {
-    // Longitude range is [0, 360], not [-180, 180], in MaRC.
-    constexpr double minimum = 0;
-    constexpr double maximum = 360;
+    using namespace MaRC::default_configuration;
+
+    // Longitude range is [0, 360] by default.
 
     return
 
@@ -81,10 +82,10 @@ bool test_longitude_scaling()
                 e.g. UCHAR_WIDTH = 8.
         */
         (sizeof(T) == 1
-         && !test_scaling<T>(minimum, maximum))
+         && !test_scaling<T>(longitude_low, longitude_high))
 
         // Integer types larger than 8 bits.
-        || test_scaling<T>(minimum, maximum);
+        || test_scaling<T>(longitude_low, longitude_high);
 }
 
 


### PR DESCRIPTION
MaRC uses magic numbers in some places rather than symbolic constants which can result in error prone code over time.  Those magic numbers should be replaced with symbolic constants as much as possible.
