### PR TITLE
Add support for GCC symbol visibility

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -140,6 +140,8 @@ AS_IF([test "x$GXX" = "xyes"],
       [XCXXFLAGS="$XCXXFLAGS -Wextra -Wformat=2 -pedantic"],
       [])
 
+AX_APPEND_COMPILE_FLAGS([-fvisibility=hidden -fvisibility-inlines-hidden])
+
 dnl Combine package set flags with user's flags.
 dnl User's flags go after package flags to allow user to override
 dnl package defaults.

--- a/lib/MaRC/BilinearInterpolation.h
+++ b/lib/MaRC/BilinearInterpolation.h
@@ -26,6 +26,7 @@
 #define MARC_BILINEAR_INTERPOLATION_H
 
 #include "MaRC/InterpolationStrategy.h"
+#include "MaRC/Export.h"
 
 #include <cstddef>
 
@@ -41,7 +42,7 @@ namespace MaRC
    * This strategy performs bilinear interpolation over 2x2 block of
    * data.
    */
-  class BilinearInterpolation : public InterpolationStrategy
+  class MARC_API BilinearInterpolation : public InterpolationStrategy
   {
   public:
 

--- a/lib/MaRC/BodyData.h
+++ b/lib/MaRC/BodyData.h
@@ -25,6 +25,8 @@
 #ifndef MARC_BODY_DATA_H
 #define MARC_BODY_DATA_H
 
+#include <MaRC/Export.h>
+
 
 namespace MaRC
 {
@@ -43,7 +45,7 @@ namespace MaRC
      *       symmetrical about their polar axis can be implemented as
      *       subclasses.
      */
-    class BodyData
+    class MARC_API BodyData
     {
     public:
 

--- a/lib/MaRC/CosPhaseImage.h
+++ b/lib/MaRC/CosPhaseImage.h
@@ -26,6 +26,7 @@
 #define MARC_COS_PHASE_IMAGE_H
 
 #include "MaRC/VirtualImage.h"
+#include "MaRC/Export.h"
 
 #include <memory>
 
@@ -44,7 +45,7 @@ namespace MaRC
      * on surface of body-Observer (phase) angle, &phi;, on the body
      * being mapped.  The observer range is taken into account.
      */
-    class CosPhaseImage : public VirtualImage
+    class MARC_API CosPhaseImage : public VirtualImage
     {
     public:
 

--- a/lib/MaRC/Export.h
+++ b/lib/MaRC/Export.h
@@ -1,0 +1,67 @@
+// -*- C++ -*-
+/**
+ * @file marc_export.h
+ *
+ * Copyright (C) 2017  Ossama Othman
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301  USA
+ *
+ * @author Ossama Othman
+ *
+ * @see http://gcc.gnu.org/wiki/Visibility
+ */
+
+#ifndef MARC_EXPORT_H
+#define MARC_EXPORT_H
+
+// Shared library support - internal macros
+#if defined _WIN32 || defined __CYGWIN__
+#  define MARC_DLL_IMPORT __declspec(dllimport)
+#  define MARC_DLL_EXPORT __declspec(dllexport)
+#  define MARC_DLL_LOCAL
+#else
+#  if __GNUC__ >= 4
+#    define MARC_DLL_IMPORT __attribute__((visibility ("default")))
+#    define MARC_DLL_EXPORT __attribute__((visibility ("default")))
+#    define MARC_DLL_LOCAL  __attribute__((visibility ("hidden")))
+#  else
+#    define MARC_DLL_IMPORT
+#    define MARC_DLL_EXPORT
+#    define MARC_DLL_LOCAL
+#    endif
+#endif
+
+// Automatically enable symbol visibility (shared library) support if
+// the "PIC" preprocessor symbol is defined.
+#if defined(PIC) && !defined(MARC_DLL) and !defined(MARC_DLL_EXPORTS)
+#  define MARC_DLL
+#  define MARC_DLL_EXPORTS
+#endif
+
+// MaRC shared library macros: MARC_API and MARC_LOCAL
+#ifdef MARC_DLL // MaRC library is compiled as a shared library (DLL)
+#  ifdef MARC_DLL_EXPORTS // MaRC DLL being built rather than used
+#    define MARC_API MARC_DLL_EXPORT
+#  else
+#    define MARC_API MARC_DLL_IMPORT
+#  endif
+#  define MARC_LOCAL MARC_DLL_LOCAL
+#else // MaRC compiled as a static library
+#  define MARC_API
+#  define MARC_LOCAL
+#endif // MARC_DLL
+
+#endif  // MARC_EXPORT_H

--- a/lib/MaRC/Export.h
+++ b/lib/MaRC/Export.h
@@ -1,6 +1,6 @@
 // -*- C++ -*-
 /**
- * @file marc_export.h
+ * @file Export.h
  *
  * Copyright (C) 2017  Ossama Othman
  *

--- a/lib/MaRC/GLLGeometricCorrection.h
+++ b/lib/MaRC/GLLGeometricCorrection.h
@@ -30,6 +30,7 @@
 #define MARC_GLL_GEOMETRIC_CORRECTION_H
 
 #include <MaRC/GeometricCorrection.h>
+#include <MaRC/Export.h>
 
 #include <cstddef>
 
@@ -49,7 +50,7 @@ namespace MaRC
      *
      * Galileo specific concrete geometric correction strategy.
      */
-    class GLLGeometricCorrection : public GeometricCorrection
+    class MARC_API GLLGeometricCorrection : public GeometricCorrection
     {
     public:
 

--- a/lib/MaRC/GeometricCorrection.h
+++ b/lib/MaRC/GeometricCorrection.h
@@ -25,6 +25,8 @@
 #ifndef MARC_GEOMETRIC_CORRECTION_H
 #define MARC_GEOMETRIC_CORRECTION_H
 
+#include <MaRC/Export.h>
+
 
 namespace MaRC
 {
@@ -38,7 +40,7 @@ namespace MaRC
      * Concrete geometric correction classes must implement the interface
      * required by this abstract base class.
      */
-    class GeometricCorrection
+    class MARC_API GeometricCorrection
     {
     public:
 

--- a/lib/MaRC/Geometry.h
+++ b/lib/MaRC/Geometry.h
@@ -28,6 +28,7 @@
 #define MARC_GEOMETRY_H
 
 #include <MaRC/Matrix.h>
+#include <MaRC/Export.h>
 
 #include <cstddef>
 
@@ -79,7 +80,7 @@ namespace MaRC
          *                   system.
          * @param[out] r     Vector in the rotated coordinate system.
          */
-        void RotX(double angle, DVector const & v, DVector & r);
+        MARC_API void RotX(double angle, DVector const & v, DVector & r);
 
         /// Rotate about y-axis.
         /**
@@ -89,7 +90,7 @@ namespace MaRC
          *                   system.
          * @param[out] r     Vector in the rotated coordinate system.
          */
-        void RotY(double angle, DVector const & v, DVector & r);
+        MARC_API void RotY(double angle, DVector const & v, DVector & r);
 
         /// Rotate about z-axis.
         /**
@@ -99,7 +100,7 @@ namespace MaRC
          *                   system.
          * @param[out] r     Vector in the rotated coordinate system.
          */
-        void RotZ(double angle, DVector const & v, DVector & r);
+        MARC_API void RotZ(double angle, DVector const & v, DVector & r);
 
         /// Return a transformation matrix that rotates a coordinate
         /// system about the x-axis.
@@ -111,7 +112,7 @@ namespace MaRC
          * @return Matrix that will rotate a coordinate system
          *         @a angle radians about the x-axis.
          */
-        DMatrix RotXMatrix(double angle);
+        MARC_API DMatrix RotXMatrix(double angle);
 
         /// Return a transformation matrix that rotates a coordinate
         /// system about the y-axis.
@@ -123,7 +124,7 @@ namespace MaRC
          * @return Matrix that will rotate a coordinate system
          *         @a angle radians about the y-axis.
          */
-        DMatrix RotYMatrix(double angle);
+        MARC_API DMatrix RotYMatrix(double angle);
 
         /// Return a transformation matrix that rotates a coordinate
         /// system about the z-axis.
@@ -135,7 +136,7 @@ namespace MaRC
          * @return Matrix that will rotate a coordinate system
          *         @a angle radians about the z-axis.
          */
-        DMatrix RotZMatrix(double angle);
+        MARC_API DMatrix RotZMatrix(double angle);
         //@}
 
     }

--- a/lib/MaRC/InterpolationStrategy.h
+++ b/lib/MaRC/InterpolationStrategy.h
@@ -25,6 +25,8 @@
 #ifndef MARC_INTERPOLATION_STRATEGY_H
 #define MARC_INTERPOLATION_STRATEGY_H
 
+#include <MaRC/Export.h>
+
 
 namespace MaRC
 {
@@ -37,7 +39,7 @@ namespace MaRC
      * Concrete interpolation classes must implement the interface
      * required by this abstract base class.
      */
-    class InterpolationStrategy
+    class MARC_API InterpolationStrategy
     {
     public:
 

--- a/lib/MaRC/LatitudeImage.h
+++ b/lib/MaRC/LatitudeImage.h
@@ -26,6 +26,7 @@
 #define MARC_LATITUDE_IMAGE_H
 
 #include "MaRC/VirtualImage.h"
+#include "MaRC/Export.h"
 
 #include <memory>
 
@@ -43,7 +44,7 @@ namespace MaRC
      * degrees.  This class may be configured to return bodygraphic
      * latitudes instead of bodycentric latitudes.
      */
-    class LatitudeImage : public VirtualImage
+    class MARC_API LatitudeImage : public VirtualImage
     {
     public:
 

--- a/lib/MaRC/LongitudeImage.h
+++ b/lib/MaRC/LongitudeImage.h
@@ -26,6 +26,7 @@
 #define MARC_LONGITUDE_IMAGE_H
 
 #include "MaRC/VirtualImage.h"
+#include "MaRC/Export.h"
 
 
 namespace MaRC
@@ -39,7 +40,7 @@ namespace MaRC
      * This concrete VirtualImage returns the given longitude in
      * degrees.
      */
-    class LongitudeImage : public VirtualImage
+    class MARC_API LongitudeImage : public VirtualImage
     {
     public:
 

--- a/lib/MaRC/Makefile.am
+++ b/lib/MaRC/Makefile.am
@@ -106,6 +106,8 @@ pkginclude_HEADERS = \
   \
   Constants.h \
   \
-  Version.h
+  Version.h \
+  \
+  Export.h
 
 # noinst_HEADERS =

--- a/lib/MaRC/MosaicImage.h
+++ b/lib/MaRC/MosaicImage.h
@@ -26,6 +26,7 @@
 #define MARC_MOSAIC_IMAGE_H
 
 #include <MaRC/SourceImage.h>
+#include <MaRC/Export.h>
 
 #include <memory>
 #include <vector>
@@ -41,7 +42,7 @@ namespace MaRC
      * Mosaics may be comprised of multiple photographs, each taken at
      * different viewing geometries.
      */
-    class MosaicImage : public SourceImage
+    class MARC_API MosaicImage : public SourceImage
     {
     public:
 

--- a/lib/MaRC/Mu0Image.h
+++ b/lib/MaRC/Mu0Image.h
@@ -26,6 +26,7 @@
 #define MARC_MU0_IMAGE_H
 
 #include "MaRC/VirtualImage.h"
+#include "MaRC/Export.h"
 
 #include <memory>
 
@@ -45,7 +46,7 @@ namespace MaRC
      * body being mapped.  The sun is assumed to be an infinite
      * distance away.
      */
-    class Mu0Image : public VirtualImage
+    class MARC_API Mu0Image : public VirtualImage
     {
     public:
 

--- a/lib/MaRC/MuImage.h
+++ b/lib/MaRC/MuImage.h
@@ -26,6 +26,7 @@
 #define MARC_MU_IMAGE_H
 
 #include "MaRC/VirtualImage.h"
+#include "MaRC/Export.h"
 
 #include <memory>
 
@@ -43,7 +44,7 @@ namespace MaRC
      * emission angle on the body being mapped.  The observer range is
      * taken into account.
      */
-    class MuImage : public VirtualImage
+    class MARC_API MuImage : public VirtualImage
     {
     public:
 

--- a/lib/MaRC/NullGeometricCorrection.h
+++ b/lib/MaRC/NullGeometricCorrection.h
@@ -26,6 +26,7 @@
 #define MARC_NULL_GEOMETRIC_CORRECTION_H
 
 #include <MaRC/GeometricCorrection.h>
+#include <MaRC/Export.h>
 
 
 namespace MaRC
@@ -38,7 +39,7 @@ namespace MaRC
      * This geometric correction strategy is a no-op.  It performs no
      * geometric correction.
      */
-    class NullGeometricCorrection : public GeometricCorrection
+    class MARC_API NullGeometricCorrection : public GeometricCorrection
     {
     public:
 

--- a/lib/MaRC/NullInterpolation.h
+++ b/lib/MaRC/NullInterpolation.h
@@ -26,6 +26,7 @@
 #define MARC_NULL_INTERPOLATION_H
 
 #include "MaRC/InterpolationStrategy.h"
+#include "MaRC/Export.h"
 
 
 namespace MaRC
@@ -39,7 +40,7 @@ namespace MaRC
      * This interpolation strategy is a no-op.  It performs no
      * interpolation.
      */
-    class NullInterpolation : public InterpolationStrategy
+    class MARC_API NullInterpolation : public InterpolationStrategy
     {
     public:
 

--- a/lib/MaRC/NullPhotometricCorrection.h
+++ b/lib/MaRC/NullPhotometricCorrection.h
@@ -39,7 +39,8 @@ namespace MaRC
      * This photometric correction strategy is a no-op.  It performs
      * no photometric correction.
      */
-    class NullPhotometricCorrection : public PhotometricCorrection
+    class MARC_API NullPhotometricCorrection
+        : public PhotometricCorrection
     {
     public:
 

--- a/lib/MaRC/OblateSpheroid.h
+++ b/lib/MaRC/OblateSpheroid.h
@@ -27,6 +27,8 @@
 
 #include <MaRC/BodyData.h>
 #include <MaRC/Vector.h>
+#include <MaRC/Export.h>
+
 
 
 namespace MaRC
@@ -41,7 +43,7 @@ namespace MaRC
      * An oblate spheroid is an ellipsoidal body with potentially
      * different equatorial and polar radii.
      */
-    class OblateSpheroid : public BodyData
+    class MARC_API OblateSpheroid : public BodyData
     {
     public:
 

--- a/lib/MaRC/PhotoImage.h
+++ b/lib/MaRC/PhotoImage.h
@@ -26,6 +26,7 @@
 #define MARC_PHOTO_IMAGE_H
 
 #include <MaRC/SourceImage.h>
+#include <MaRC/Export.h>
 
 #include <memory>
 #include <vector>
@@ -46,7 +47,7 @@ namespace MaRC
      * photos of the same body being mapped.  For example, photos from
      * telescope observations fit into this category.
      */
-    class PhotoImage : public SourceImage
+    class MARC_API PhotoImage : public SourceImage
     {
     public:
 

--- a/lib/MaRC/PhotoImageParameters.h
+++ b/lib/MaRC/PhotoImageParameters.h
@@ -27,6 +27,8 @@
 
 #include "MaRC/PhotometricCorrection.h"
 #include "MaRC/InterpolationStrategy.h"
+#include "MaRC/Export.h"
+
 
 #include <memory>
 
@@ -39,7 +41,7 @@ namespace MaRC
      *
      * @brief Configuration parameters specific to @c PhotoImage.
      */
-    class PhotoImageParameters
+    class MARC_API PhotoImageParameters
     {
     public:
 

--- a/lib/MaRC/PhotometricCorrection.h
+++ b/lib/MaRC/PhotometricCorrection.h
@@ -25,6 +25,8 @@
 #ifndef MARC_PHOTOMETRIC_CORRECTION_H
 #define MARC_PHOTOMETRIC_CORRECTION_H
 
+#include <MaRC/Export.h>
+
 
 namespace MaRC
 {
@@ -41,7 +43,7 @@ namespace MaRC
      * darkening).  All such photometric metric correction strategies
      * should inherit from this base class.
      */
-    class PhotometricCorrection
+    class MARC_API PhotometricCorrection
     {
     public:
 

--- a/lib/MaRC/SourceImage.h
+++ b/lib/MaRC/SourceImage.h
@@ -26,6 +26,8 @@
 #ifndef MARC_SOURCE_IMAGE_H
 #define MARC_SOURCE_IMAGE_H
 
+#include <MaRC/Export.h>
+
 #include <cstddef>
 
 
@@ -39,7 +41,7 @@ namespace MaRC
      * Concrete source image classes must implement the interface
      * required by this abstract base class.
      */
-    class SourceImage
+    class MARC_API SourceImage
     {
     public:
 

--- a/lib/MaRC/Version.h
+++ b/lib/MaRC/Version.h
@@ -27,6 +27,8 @@
 #ifndef MARC_LIB_VERSION_H
 #define MARC_LIB_VERSION_H
 
+#include "MaRC/Export.h"
+
 
 namespace MaRC
 {
@@ -35,7 +37,7 @@ namespace MaRC
      *
      * @return String containing the MaRC library version.
      */
-    char const * library_version();
+    MARC_API char const * library_version();
 }
 
 

--- a/lib/MaRC/ViewingGeometry.h
+++ b/lib/MaRC/ViewingGeometry.h
@@ -27,6 +27,7 @@
 
 #include "MaRC/Geometry.h"
 #include "MaRC/GeometricCorrection.h"
+#include "MaRC/Export.h"
 
 #include <vector>
 #include <cstddef>
@@ -52,7 +53,7 @@ namespace MaRC
      *       an oblate spheroid due to the way the rotation matrices
      *       are generated.
      */
-    class ViewingGeometry
+    class MARC_API ViewingGeometry
     {
     public:
 

--- a/lib/MaRC/VirtualImage.h
+++ b/lib/MaRC/VirtualImage.h
@@ -26,6 +26,7 @@
 #define MARC_VIRTUAL_IMAGE_H
 
 #include "MaRC/SourceImage.h"
+#include <MaRC/Export.h>
 
 #include <limits>
 #include <cmath>
@@ -246,7 +247,7 @@ namespace MaRC
      * retrieved from static sources such as images stored on a
      * filesystem.
      */
-    class VirtualImage : public SourceImage
+    class MARC_API VirtualImage : public SourceImage
     {
     public:
 


### PR DESCRIPTION
Leverage GCC symbol visibility when available to enable improved shared library binary generation.  The improvement is very slight with the current source code, but should be better once more code is not exported to the user.  This also lays the groundwork necessary to support Windows DLLs.

