### PR TITLE
Implement link-time optimizations

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -45,6 +45,9 @@
 - Improved speed of MU, MU0 and PHASE virtual image generation by up
   to 100% by dropping a redundant data "visibility" check.
 
+- Slightly improved overall MaRC performance by leveraging link-time
+  optimization on some platforms.
+
 - Corrected problem in conformal (Mercator and Polar Stereographic)
   maps that prevented calculation of latitudes for the entire map from
   completing in some cases.

--- a/configure.ac
+++ b/configure.ac
@@ -131,9 +131,17 @@ AC_HEADER_STDC
 
 dnl System specific configuration
 AS_IF([test "x$ax_enable_debug" != "xyes"],
-      [marc_optimization_flag="-O2"
+      [
+       dnl Compile-time optimization
+       marc_optimization_flag="-O2"
        AX_CHECK_COMPILE_FLAG([$marc_optimization_flag],
                              [AX_APPEND_FLAG([$marc_optimization_flag],
+                                             [XCXXFLAGS])])
+
+       dnl Link-time optimization
+       marc_lto_flag="-flto"
+       AX_CHECK_COMPILE_FLAG([$marc_lto_flag],
+                             [AX_APPEND_FLAG([$marc_lto_flag],
                                              [XCXXFLAGS])])
       ])
 

--- a/lib/MaRC/BilinearInterpolation.h
+++ b/lib/MaRC/BilinearInterpolation.h
@@ -42,7 +42,8 @@ namespace MaRC
    * This strategy performs bilinear interpolation over 2x2 block of
    * data.
    */
-  class MARC_API BilinearInterpolation : public InterpolationStrategy
+  class MARC_API BilinearInterpolation final
+      : public InterpolationStrategy
   {
   public:
 

--- a/lib/MaRC/CosPhaseImage.h
+++ b/lib/MaRC/CosPhaseImage.h
@@ -45,7 +45,7 @@ namespace MaRC
      * on surface of body-Observer (phase) angle, &phi;, on the body
      * being mapped.  The observer range is taken into account.
      */
-    class MARC_API CosPhaseImage : public VirtualImage
+    class MARC_API CosPhaseImage final : public VirtualImage
     {
     public:
 

--- a/lib/MaRC/GLLGeometricCorrection.h
+++ b/lib/MaRC/GLLGeometricCorrection.h
@@ -50,7 +50,8 @@ namespace MaRC
      *
      * Galileo specific concrete geometric correction strategy.
      */
-    class MARC_API GLLGeometricCorrection : public GeometricCorrection
+    class MARC_API GLLGeometricCorrection final
+        : public GeometricCorrection
     {
     public:
 

--- a/lib/MaRC/LatitudeImage.h
+++ b/lib/MaRC/LatitudeImage.h
@@ -44,7 +44,7 @@ namespace MaRC
      * degrees.  This class may be configured to return bodygraphic
      * latitudes instead of bodycentric latitudes.
      */
-    class MARC_API LatitudeImage : public VirtualImage
+    class MARC_API LatitudeImage final : public VirtualImage
     {
     public:
 

--- a/lib/MaRC/LongitudeImage.h
+++ b/lib/MaRC/LongitudeImage.h
@@ -40,7 +40,7 @@ namespace MaRC
      * This concrete VirtualImage returns the given longitude in
      * degrees.
      */
-    class MARC_API LongitudeImage : public VirtualImage
+    class MARC_API LongitudeImage final : public VirtualImage
     {
     public:
 

--- a/lib/MaRC/Mercator.h
+++ b/lib/MaRC/Mercator.h
@@ -53,7 +53,7 @@ namespace MaRC
      * @note This implementation can only map oblate spheroids or
      *       spheres.
      */
-    class MARC_API Mercator : public MapFactory
+    class MARC_API Mercator final : public MapFactory
     {
     public:
 

--- a/lib/MaRC/MosaicImage.h
+++ b/lib/MaRC/MosaicImage.h
@@ -42,7 +42,7 @@ namespace MaRC
      * Mosaics may be comprised of multiple photographs, each taken at
      * different viewing geometries.
      */
-    class MARC_API MosaicImage : public SourceImage
+    class MARC_API MosaicImage final : public SourceImage
     {
     public:
 

--- a/lib/MaRC/Mu0Image.h
+++ b/lib/MaRC/Mu0Image.h
@@ -46,7 +46,7 @@ namespace MaRC
      * body being mapped.  The sun is assumed to be an infinite
      * distance away.
      */
-    class MARC_API Mu0Image : public VirtualImage
+    class MARC_API Mu0Image final : public VirtualImage
     {
     public:
 

--- a/lib/MaRC/MuImage.h
+++ b/lib/MaRC/MuImage.h
@@ -44,7 +44,7 @@ namespace MaRC
      * emission angle on the body being mapped.  The observer range is
      * taken into account.
      */
-    class MARC_API MuImage : public VirtualImage
+    class MARC_API MuImage final : public VirtualImage
     {
     public:
 

--- a/lib/MaRC/NullInterpolation.h
+++ b/lib/MaRC/NullInterpolation.h
@@ -40,7 +40,7 @@ namespace MaRC
      * This interpolation strategy is a no-op.  It performs no
      * interpolation.
      */
-    class MARC_API NullInterpolation : public InterpolationStrategy
+    class MARC_API NullInterpolation final : public InterpolationStrategy
     {
     public:
 

--- a/lib/MaRC/OblateSpheroid.h
+++ b/lib/MaRC/OblateSpheroid.h
@@ -43,7 +43,7 @@ namespace MaRC
      * An oblate spheroid is an ellipsoidal body with potentially
      * different equatorial and polar radii.
      */
-    class MARC_API OblateSpheroid : public BodyData
+    class MARC_API OblateSpheroid final : public BodyData
     {
     public:
 

--- a/lib/MaRC/Orthographic.h
+++ b/lib/MaRC/Orthographic.h
@@ -49,7 +49,7 @@ namespace MaRC
      * @note Only bodies modeled as oblate spheroids are supported by
      *       this implementation.
      */
-    class MARC_API Orthographic : public MapFactory
+    class MARC_API Orthographic final : public MapFactory
     {
     public:
 

--- a/lib/MaRC/PhotoImage.h
+++ b/lib/MaRC/PhotoImage.h
@@ -47,7 +47,7 @@ namespace MaRC
      * photos of the same body being mapped.  For example, photos from
      * telescope observations fit into this category.
      */
-    class MARC_API PhotoImage : public SourceImage
+    class MARC_API PhotoImage final : public SourceImage
     {
     public:
 

--- a/lib/MaRC/PolarStereographic.h
+++ b/lib/MaRC/PolarStereographic.h
@@ -46,7 +46,7 @@ namespace MaRC
      * @note This implementation can only map oblate spheroids or
      *       spheres.
      */
-    class MARC_API PolarStereographic : public MapFactory
+    class MARC_API PolarStereographic final : public MapFactory
     {
     public:
 

--- a/lib/MaRC/SimpleCylindrical.h
+++ b/lib/MaRC/SimpleCylindrical.h
@@ -47,7 +47,7 @@ namespace MaRC
      * projection, as well as rectangular, equirectangular and
      * equidistant cylindrical.
      */
-    class MARC_API SimpleCylindrical : public MapFactory
+    class MARC_API SimpleCylindrical final : public MapFactory
     {
     public:
 

--- a/src/CosPhaseImageFactory.h
+++ b/src/CosPhaseImageFactory.h
@@ -40,7 +40,7 @@ namespace MaRC
      *
      * This class creates CosPhaseImage objects.
      */
-    class CosPhaseImageFactory : public ImageFactory
+    class CosPhaseImageFactory final : public ImageFactory
     {
     public:
 

--- a/src/LatitudeImageFactory.h
+++ b/src/LatitudeImageFactory.h
@@ -38,7 +38,7 @@ namespace MaRC
      *
      * This class creates @c LatitudeImage objects.
      */
-    class LatitudeImageFactory : public ImageFactory
+    class LatitudeImageFactory final : public ImageFactory
     {
     public:
 

--- a/src/LongitudeImageFactory.h
+++ b/src/LongitudeImageFactory.h
@@ -37,7 +37,7 @@ namespace MaRC
      *
      * This class creates LongitudeImage objects.
      */
-    class LongitudeImageFactory : public ImageFactory
+    class LongitudeImageFactory final : public ImageFactory
     {
     public:
 

--- a/src/MapCommand_T.h
+++ b/src/MapCommand_T.h
@@ -44,7 +44,7 @@ namespace MaRC
      * code that executes MapCommands.
      */
     template <typename T>
-    class MapCommand_T : public MapCommand
+    class MapCommand_T final : public MapCommand
     {
     public:
 

--- a/src/MosaicImageFactory.h
+++ b/src/MosaicImageFactory.h
@@ -47,7 +47,7 @@ namespace MaRC
      * the MosaicImage to be mapped, which reduces run-time memory
      * requirements.
      */
-    class MosaicImageFactory : public ImageFactory
+    class MosaicImageFactory final : public ImageFactory
     {
     public:
 

--- a/src/Mu0ImageFactory.h
+++ b/src/Mu0ImageFactory.h
@@ -38,7 +38,7 @@ namespace MaRC
      *
      * This class creates Mu0Image objects.
      */
-    class Mu0ImageFactory : public ImageFactory
+    class Mu0ImageFactory final : public ImageFactory
     {
     public:
 

--- a/src/MuImageFactory.h
+++ b/src/MuImageFactory.h
@@ -38,7 +38,7 @@ namespace MaRC
      *
      * This class creates @c MuImage objects.
      */
-    class MuImageFactory : public ImageFactory
+    class MuImageFactory final : public ImageFactory
     {
     public:
 

--- a/src/PhotoImageFactory.h
+++ b/src/PhotoImageFactory.h
@@ -50,7 +50,7 @@ namespace MaRC
      * the PhotoImage to be mapped, which reduces run-time memory
      * requirements.
      */
-    class PhotoImageFactory : public ImageFactory
+    class PhotoImageFactory final : public ImageFactory
     {
     public:
 


### PR DESCRIPTION
- Declare C++ types that won't be inherited as `final` to allow additional compile- and link-time optimizations to occurs, such as de-virtualization of method calls.
- Enable link-time optimization flag, i.e. `-flto` for GCC and Clang.
