### PR TITLE
Use NAIF recommended terminology

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,6 @@ script:
 before_install:
     - eval "${MATRIX_EVAL}"
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew tap homebrew/science; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install cfitsio bison flex texinfo autoconf-archive; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
           for p in bison gettext flex texinfo; do

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,7 @@
+- Replaced all uses of the MaRC-specific "bodycentric" and
+  "bodygraphic" latitude terminology with the NASA NAIF recommended
+  "planetocentric" and "planetographic", respectively.
+
 31 January 2018 - MaRC 0.9.10
 
 - Reduced footprint of the MaRC program (`marc') and library

--- a/doc/MaRC_input.texi
+++ b/doc/MaRC_input.texi
@@ -15,7 +15,7 @@ last updated @value{UPDATED},
 of @cite{The MaRC Manual},
 for @code{MaRC}, version @value{VERSION}.
 
-Copyright @copyright{} 1997-1999, 2003, 2004, 2017  Ossama Othman
+Copyright @copyright{} 1997-1999, 2003-2004, 2017-2018  Ossama Othman
 
 @quotation
 Permission is granted to copy, distribute and/or modify this document
@@ -234,16 +234,16 @@ Note that the arguments for the trigonometric functions @code{sin},
 @comment node-name,     next,           previous, up
 @cindex Angle and Range Entries
 @section Angle and Range Entries
-Special cases of keyword entries that expect mathematical expressions as
-their semantic values exists when specifying latitudes, longitudes,
+Special cases of keyword entries that expect mathematical expressions
+as their semantic values exists when specifying latitudes, longitudes,
 position angles and ranges.  Here is an example of a latitude and
 longitude entry, the keywords will be discussed later on:
 
 @cindex @code{SUB_OBSERV_LAT}
 @cindex @code{SUB_OBSERV_LON}
 @example
-SUB_OBSERV_LAT: 34 N C  # Specifies 34 degrees North bodycentric lat.
-SUB_OBSERV_LON: 25.6 W  # Specifies 25.6 degrees West longitude
+SUB_OBSERV_LAT: 34 N C  # 34 degrees North planetocentric latitude
+SUB_OBSERV_LON: 25.6 W  # 25.6 degrees West longitude
 @end example
 
 @noindent
@@ -253,16 +253,16 @@ north latitude.  Similarly @code{S} denotes south latitude.  If neither
 expression entered for the latitude determines the hemisphere of the
 sub-observation latitude.  A positive value indicates the northern
 hemisphere, where a negative value indicates the southern hemisphere.
-The letter @code{C} after @code{N} in this example denotes a bodycentric
-latitude.  The letter @code{G} may be used to denote a bodygraphic
-latitude.  If neither @code{C} nor @code{G} is used then a bodycentric
-latitude will be assumed.  A space must be placed between the hemisphere
-and latitude type letters.  Longitudes can be denoted by the letters
-@code{E} and @code{W} for east and west longitude, respectively.  If
-neither is specified, then the direction of rotation of the body
-determines whether the longitude is east or west longitude.  Prograde
-rotation causes the longitude to be west by default, whereas a
-retrograde rotation defaults to east longitude.
+The letter @code{C} after @code{N} in this example denotes a
+planetocentric latitude.  The letter @code{G} may be used to denote a
+planetographic latitude.  If neither @code{C} nor @code{G} is used
+then a planetocentric latitude will be assumed.  A space must be
+placed between the hemisphere and latitude type letters.  Longitudes
+can be denoted by the letters @code{E} and @code{W} for east and west
+longitude, respectively.  If neither is specified, then the direction
+of rotation of the body determines whether the longitude is east or
+west longitude.  Prograde rotation causes the longitude to be west by
+default, whereas a retrograde rotation defaults to east longitude.
 
 A similar expression may be entered for the position angle as follows:
 @cindex clockwise
@@ -500,8 +500,8 @@ integer (8 bits) format.  As such, the minimum value is zero and the
 maximum value is 255.  Grid points and lines have an intensity value of
 255.  It is also possible to specify the interval between points of
 constant latitude and of constant longitude.  By default the interval
-between grid points is 10 degrees (bodycentric where applicable
-@c -- see the appendix for a description of bodycentric latitudes
+between grid points is 10 degrees (planetocentric where applicable
+@c -- see the appendix for a description of planetocentric latitudes
 ).  Both are used in the following fashion:
 @cindex @code{GRID}
 @cindex @code{GRID_INTERVAL}
@@ -982,8 +982,8 @@ set by using the @code{SUB_OBSERV_LAT} and @code{SUB_OBSERV_LON}
 keywords as follows:
 
 @example
-SUB_OBSERV_LAT: 34 N C  # Specifies 34 degrees North bodycentric lat.
-SUB_OBSERV_LON: 25.6 W  # Specifies 25.6 degrees West longitude
+SUB_OBSERV_LAT: 34 N C  # 34 degrees North planetocentric latitude
+SUB_OBSERV_LON: 25.6 W  # 25.6 degrees West longitude
 @end example
 
 The position angle, sometimes referred to as the north angle is
@@ -1153,8 +1153,8 @@ set by using the @code{SUB_OBSERV_LAT} and @code{SUB_OBSERV_LON}
 keywords as follows:
 
 @example
-SUB_OBSERV_LAT: 34 N C  # Specifies 34 degrees North bodycentric lat.
-SUB_OBSERV_LON: 25.6 W  # Specifies 25.6 degrees West longitude
+SUB_OBSERV_LAT: 34 N C  # 34 degrees North planetocentric latitude
+SUB_OBSERV_LON: 25.6 W  # 25.6 degrees West longitude
 @end example
 
 The position angle, sometimes referred to as the north angle is
@@ -1287,8 +1287,8 @@ The simple cylindrical projection is a projection that simply maps
 latitudes as horizontal lines and longitudes as vertical lines.  Pixel
 distances between latitude lines are uniform throughout the map, and
 similarly for longitudes.  It is possible to map data using either
-bodycentric or bodygraphic latitudes.  Also, latitude and longitude
-ranges to be mapped can also be specified.
+planetocentric or planetographic latitudes.  Also, latitude and
+longitude ranges to be mapped can also be specified.
 @cindex @code{LATITUDE_TYPE}
 @cindex @code{CENTRIC_LAT}
 @cindex @code{GRAPHIC_LAT}
@@ -1297,19 +1297,20 @@ ranges to be mapped can also be specified.
 @cindex @code{LO_LON}
 @cindex @code{HI_LON}
 The latitude type is set using the @code{LATITUDE_TYPE} keyword.  To
-choose a bodycentric latitude map, the keyword token
-@code{@w{CENTRIC_LAT}} is used.  Bodygraphic latitudes are selected by
-using the @code{GRAPHIC_LAT} keyword token. The latitude range is set by
-using the @code{LO_LAT} and @code{HI_LAT} keywords, while the longitude
-range is set by using the @code{LO_LON} and @code{HI_LON} keywords.  The
-latitude and longitude options as described earlier (@pxref{Angle &
-Range}) also hold for these latitude/longitude range keywords.  Both
-latitude range keywords must be used if setting a latitude range and
-similarly for the longitude range.  However, the latitude and longitude
-range keywords need not always be used.  If the latitude range is not
-specified MaRC will then default to the full latitude range, and
-similarly for the longitude range.  The following is an example of how a
-simple cylindrical projection is entered in to a MaRC input file:
+choose a planetocentric latitude map, the keyword token
+@code{@w{CENTRIC_LAT}} is used.  Planetographic latitudes are selected by
+using the @code{GRAPHIC_LAT} keyword token. The latitude range is set
+by using the @code{LO_LAT} and @code{HI_LAT} keywords, while the
+longitude range is set by using the @code{LO_LON} and @code{HI_LON}
+keywords.  The latitude and longitude options as described earlier
+(@pxref{Angle & Range}) also hold for these latitude/longitude range
+keywords.  Both latitude range keywords must be used if setting a
+latitude range and similarly for the longitude range.  However, the
+latitude and longitude range keywords need not always be used.  If the
+latitude range is not specified MaRC will then default to the full
+latitude range, and similarly for the longitude range.  The following
+is an example of how a simple cylindrical projection is entered in to
+a MaRC input file:
 
 @cindex @code{OPTIONS}
 @example
@@ -1324,8 +1325,8 @@ TYPE:   SIMPLE_C
 @end example
 
 @noindent
-Note that it is valid to enter a value for @code{LO_LON} that is greater
-than @code{HI_LON}, if so desired.
+Note that it is valid to enter a value for @code{LO_LON} that is
+greater than @code{HI_LON}, if so desired.
 
 @node    Map Size,  Map Planes, Projections,  Input Files
 @comment node-name,     next,           previous, up
@@ -1334,8 +1335,8 @@ than @code{HI_LON}, if so desired.
 @cindex @code{SAMPLES}
 @cindex @code{LINES}
 In general most maps have only two dimensions: the number of
-@emph{samples} and the number of @emph{lines}.  Each of these dimensions
-are set with the @code{SAMPLES} and @code{LINES} keywords,
+@emph{samples} and the number of @emph{lines}.  Each of these
+dimensions are set with the @code{SAMPLES} and @code{LINES} keywords,
 respectively.  The keyword @code{SAMPLES} refers to the number of
 columns in a map.  The @code{LINES} keyword refers to the number of
 rows in a map.  An example of a map size entry is:
@@ -1349,8 +1350,8 @@ MaRC can also create multi-plane maps.  Such a map or ``map cube''
 would have several planes each with a different set of data.  Both
 single plane maps and multi-plane maps are defined using the same
 keywords, the only difference being more than one @emph{plane}
-(@pxref{Map Planes}) definition in the multi-plane map case.  Note that
-a map must have at least one plane.
+(@pxref{Map Planes}) definition in the multi-plane map case.  Note
+that a map must have at least one plane.
 
 @node    Map Planes,  Sample Input File,  Map Size,  Input Files
 @comment node-name,     next,           previous, up
@@ -1360,8 +1361,8 @@ a map must have at least one plane.
 Multiple planes, each containing a different set of data for the map
 projection, may exist.  This section describes how different type map
 planes may be configured.  A map plane may either contain data
-retrieved from a static source (e.g. an image file) or data
-computed dynamically at run-time.
+retrieved from a static source (e.g. an image file) or data computed
+dynamically at run-time.
 
 @menu
 * Beginning a Plane::     How to begin a plane entry.
@@ -1784,8 +1785,8 @@ set by using the @code{SUB_OBSERV_LAT} and @code{SUB_OBSERV_LON}
 keywords as follows:
 
 @example
-SUB_OBSERV_LAT: 34 N C  # Specifies 34 degrees North bodycentric lat.
-SUB_OBSERV_LON: 25.6 W  # Specifies 25.6 degrees West longitude
+SUB_OBSERV_LAT: 34 N C  # 34 degrees North planetocentric latitude
+SUB_OBSERV_LON: 25.6 W  # 25.6 degrees West longitude
 @end example
 
 @node    Pos. Ang.,  Sub-Solar Pt.,  Sub-Observer Pt.,  Image Geometry
@@ -1826,8 +1827,8 @@ through.  The sub-solar point is set by using the @code{SUB_SOLAR_LAT}
 and @code{SUB_SOLAR_LON} keywords as follows:
 
 @example
-SUB_SOLAR_LAT:  3.2 S C # Specifies 3.2 degrees South bodycentric lat.
-SUB_SOLAR_LON:  15  W   # Specifies 15 degrees West longitude
+SUB_SOLAR_LAT:  3.2 S C # 3.2 degrees South planetocentric latitude.
+SUB_SOLAR_LON:  15  W   # 15 degrees West longitude
 @end example
 
 @node    Range,   ,  Sub-Solar Pt.,  Image Geometry

--- a/lib/MaRC/BodyData.h
+++ b/lib/MaRC/BodyData.h
@@ -2,7 +2,7 @@
 /**
  * @file BodyData.h
  *
- * Copyright (C) 1999, 2003-2004, 2017  Ossama Othman
+ * Copyright (C) 1999, 2003-2004, 2017-2018  Ossama Othman
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -69,14 +69,13 @@ namespace MaRC
          */
         bool prograde() const { return this->prograde_; }
 
-        /// Find radius as a function of bodycentric latitude.
+        /// Find radius as a function of planetocentric latitude.
         /**
          * Calculate and return the radius, i.e. distance from the
          * center of the body to the point on the surface at given
          * latitude.
          *
-         * @param[in] lat Bodycentric (e.g. planetocentric) latitude
-         *                in radians.
+         * @param[in] lat Planetocentric latitude in radians.
          *
          * @return Radius, i.e. distance from the center of the body
          *         to point on the surface at given latitude.
@@ -87,12 +86,11 @@ namespace MaRC
          */
         virtual double centric_radius(double lat) const = 0;
 
-        /// Convert from GRAPHIC to CENTRIC latitude
+        /// Convert from planeteographic to planetocentric latitude.
         /**
-         * @param[in] latg Graphic (e.g. planetographic) latitude in
-         *                 radians.
+         * @param[in] latg Planetographic latitude in radians.
          *
-         * @return Bodycentric latitude in radians.
+         * @return Planetocentric latitude in radians.
          *
          * @todo We really should add a longitude parameter since not
          *       all bodies are symmetrical about their polar axis.
@@ -100,12 +98,11 @@ namespace MaRC
          */
         virtual double centric_latitude(double latg) const = 0;
 
-        /// Convert from CENTRIC to GRAPHIC latitude
+        /// Convert from planetocentric to planetographic latitude.
         /**
-         * @param[in] lat Centric (e.g. planetocentric) latitude in
-         *                radians.
+         * @param[in] lat Planetocentric latitude in radians.
          *
-         * @return Bodygraphic latitude in radians.
+         * @return Planetographic latitude in radians.
          *
          * @todo We really should add a longitude parameter since not
          *       all bodies are symmetrical about their polar axis.
@@ -114,13 +111,13 @@ namespace MaRC
 
         /// Return cosine of emission angle, i.e. &mu;
         /**
-         * @param[in] sub_observ_lat Bodycentric subobservation
-         *                           latitude
-         * @param[in] sub_observ_lon Subobservation longitude
-         * @param[in] lat            Bodycentric latitude
-         * @param[in] lon            Longitude
-         * @param[in] range          Observer range to subobservation
-         *                           point
+         * @param[in] sub_observ_lat Planetocentric sub-observation
+         *                           latitude.
+         * @param[in] sub_observ_lon Sub-Observation longitude.
+         * @param[in] lat            Planetocentric latitude.
+         * @param[in] lon            Longitude.
+         * @param[in] range          Observer range to sub-observation
+         *                           point.
          *
          * @return Cosine of emission angle, i.e. &mu;.
          */
@@ -132,10 +129,11 @@ namespace MaRC
 
         /// Return cosine of incidence angle, i.e. &mu;<SUB>0</SUB>
         /**
-         * @param[in] sub_solar_lat Bodycentric subsolar latitude
-         * @param[in] sub_solar_lon Subsolar longitude
-         * @param[in] lat           Bodycentric latitude
-         * @param[in] lon           Longitude
+         * @param[in] sub_solar_lat Planetocentric sub-solar
+         *                          latitude.
+         * @param[in] sub_solar_lon Sub-Solar longitude.
+         * @param[in] lat           Planetocentric latitude.
+         * @param[in] lon           Longitude.
          *
          * @return Cosine of incidence angle, i.e. &mu;<SUB>0</SUB>.
          *
@@ -148,15 +146,16 @@ namespace MaRC
 
         /// Return cosine of phase angle, i.e. @c cos(&phi;)
         /**
-         * @param[in] sub_observ_lat Bodycentric subobservation
-         *                           latitude
-         * @param[in] sub_observ_lon Subobservation longitude
-         * @param[in] sub_solar_lat  Bodycentric subsolar latitude
-         * @param[in] sub_solar_lon  Subsolar longitude
-         * @param[in] lat            Bodycentric latitude
-         * @param[in] lon            Longitude
-         * @param[in] range          Observer range to subobservation
-         *                           point
+         * @param[in] sub_observ_lat Planetocentric sub-observation
+         *                           latitude.
+         * @param[in] sub_observ_lon Sub-observation longitude.
+         * @param[in] sub_solar_lat  Planetocentric sub-solar
+         *                           latitude.
+         * @param[in] sub_solar_lon  Sub-solar longitude.
+         * @param[in] lat            Planetocentric latitude.
+         * @param[in] lon            Longitude.
+         * @param[in] range          Observer range to sub-observation.
+         *                           point.
          *
          * @return Cosine of phase angle, i.e. @c cos(&phi;).
          */
@@ -170,9 +169,10 @@ namespace MaRC
 
     private:
 
-        /// Flag that states whether the body rotation is prograde or
-        /// retrograde.
         /**
+         * @brief Flag that states whether the body rotation is
+         *        prograde or retrograde.
+         *
          * prograde == @c true, retrograde == @c false
          */
         bool const prograde_;

--- a/lib/MaRC/CosPhaseImage.h
+++ b/lib/MaRC/CosPhaseImage.h
@@ -2,7 +2,7 @@
 /**
  *  @file CosPhaseImage.h
  *
- * Copyright (C) 2003-2004, 2017  Ossama Othman
+ * Copyright (C) 2003-2004, 2017-2018  Ossama Othman
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -53,11 +53,12 @@ namespace MaRC
         /**
          * @param[in] body           Object representing the body
          *                           being mapped.
-         * @param[in] sub_observ_lat Bodycentric sub-observer latitude
-         *                           in degrees.
+         * @param[in] sub_observ_lat Planetocentric sub-observer
+         *                           latitude in degrees.
          * @param[in] sub_observ_lon Sub-observer longitude in
          *                           degrees.
-         * @param[in] sub_solar_lat  Sub-solar latitude in degrees.
+         * @param[in] sub_solar_lat  Planetocentric sub-solar latitude
+         *                           in degrees.
          * @param[in] sub_solar_lon  Sub-solar longitude in degrees.
          * @param[in] range          Observer to target center
          *                           distance.
@@ -91,7 +92,7 @@ namespace MaRC
         /// Object representing the body being mapped.
         std::shared_ptr<BodyData> const body_;
 
-        /// Bodycentric sub-observer latitude in radians.
+        /// Planetocentric sub-observer latitude in radians.
         double const sub_observ_lat_;
 
         /// Sub-observer longitude in radians.

--- a/lib/MaRC/LatitudeImage.h
+++ b/lib/MaRC/LatitudeImage.h
@@ -2,7 +2,7 @@
 /**
  * @file LatitudeImage.h
  *
- * Copyright (C) 2003-2004, 2017  Ossama Othman
+ * Copyright (C) 2003-2004, 2017-2018  Ossama Othman
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -41,8 +41,8 @@ namespace MaRC
      * @brief Latitude virtual image.
      *
      * This concrete VirtualImage returns the given latitude in
-     * degrees.  This class may be configured to return bodygraphic
-     * latitudes instead of bodycentric latitudes.
+     * degrees.  This class may be configured to return planetographic
+     * latitudes instead of planetocentric latitudes.
      */
     class MARC_API LatitudeImage final : public VirtualImage
     {
@@ -53,9 +53,9 @@ namespace MaRC
          * @param[in] body              Pointer to BodyData object
          *                              representing body being
          *                              mapped.
-         * @param[in] graphic_latitudes Return bodygraphic latitudes
-         *                              instead of bodycentric
-         *                              latitudes.
+         * @param[in] graphic_latitudes Return planetographic
+         *                              latitudes instead of
+         *                              planetocentric latitudes.
          * @param[in] scale             Linear scaling value by which
          *                              latitudes should be
          *                              multiplied.
@@ -97,8 +97,8 @@ namespace MaRC
         /// Object representing the body being mapped.
         std::shared_ptr<BodyData> body_;
 
-        /// Flag that determines if bodygraphic latitudes are returned
-        /// instead of bodycentric latitudes.
+        /// Flag that determines if planetographic latitudes are
+        /// returned instead of planetocentric latitudes.
         bool const graphic_latitudes_;
 
   };

--- a/lib/MaRC/MapFactory.h
+++ b/lib/MaRC/MapFactory.h
@@ -174,8 +174,8 @@ namespace MaRC
          *                                 map, i.e. all data less
          *                                 than or equal to
          *                                 @a maximum.
-         * @param[in]     lat              Bodycentric latitude
-         * @param[in]     lon              Bodycentric longitude
+         * @param[in]     lat              Planetocentric latitude.
+         * @param[in]     lon              Planetocentric longitude.
          * @param[in]     percent_complete Percent of map completed.
          * @param[in]     offset           Map offset corresponding to
          *                                 the location in the

--- a/lib/MaRC/Mercator.cpp
+++ b/lib/MaRC/Mercator.cpp
@@ -40,7 +40,7 @@ namespace
     /**
      * @param[in] body Reference to @c OblateSpheroid object
      *                 representing body being mapped.
-     * @param[in] latg Bodygraphic latitude.
+     * @param[in] latg Planetographic latitude.
      *
      * @return Value of point on projection along a vertical axis
      *         (e.g. along a longitude line).
@@ -154,7 +154,7 @@ MaRC::Mercator::plot_map(std::size_t samples,
          *       on numerical differentation techniques, to speed up
          *       root finding and improve accuracy.
          */
-        // bodyGRAPHIC latitude.
+        // planetoGRAPHIC latitude.
         double const latg =
             MaRC::root_find(x, ll, ul, map_equation);
 
@@ -166,7 +166,7 @@ MaRC::Mercator::plot_map(std::size_t samples,
          //           << k << ", "
          //           << latg / C::degree << ")\n";
 
-        // Convert to bodyCENTRIC latitude
+        // Convert to planetoCENTRIC latitude
         double const lat = this->body_->centric_latitude(latg);
 
         for (std::size_t i = 0; i < samples; ++i, ++offset) {
@@ -202,7 +202,7 @@ MaRC::Mercator::plot_grid(std::size_t samples,
 
     // Draw latitude lines
     for (double n = -90 + lat_interval; n < 90; n += lat_interval) {
-        // Convert to bodygraphic latitude
+        // Convert to planetographic latitude
         double const nn = this->body_->graphic_latitude(n * C::degree);
         double const k =
             std::round(mercator_x(*this->body_, nn) / pix_conv_val
@@ -261,15 +261,16 @@ double
 MaRC::Mercator::distortion(double latg) const
 {
     /**
-     * @todo A graphic latitude is required as the argument which is
-     *       converted to a centric latitude before being passed to
-     *       the @c N() method below, which in turn converts back to a
-     *       graphic latitude before performing any calculations.
-     *       Tweak the method parameters to avoid the redundant
-     *       graphic/centric latitude conversions.
+     * @todo A planetographic latitude is required as the argument
+     *       which is converted to a planetocentric latitude before
+     *       being passed to the @c N() method below, which in turn
+     *       converts back to a planetographic latitude before
+     *       performing any calculations.  Tweak the method parameters
+     *       to avoid the redundant planetographic/centric latitude
+     *       conversions.
      */
 
-    // Note that latitude is bodyGRAPHIC.
+    // Note that latitude is planetoGRAPHIC.
     return
         this->body_->eq_rad()
         / this->body_->N(this->body_->centric_latitude(latg))

--- a/lib/MaRC/Mercator.h
+++ b/lib/MaRC/Mercator.h
@@ -85,10 +85,11 @@ namespace MaRC
         virtual char const * projection_name() const;
         //@}
 
-        /// Scale distortion at given bodygraphic latitude @a latg on
-        /// map.
         /**
-         * @param[in] latg Bodygraphic latitude.
+         * @brief Scale distortion at given planetographic latitude
+         *        @a latg on map.
+         *
+         * @param[in] latg Planetographic latitude.
          */
         double distortion(double latg) const;
 

--- a/lib/MaRC/MosaicImage.h
+++ b/lib/MaRC/MosaicImage.h
@@ -2,7 +2,7 @@
 /**
  * @file MosaicImage.h
  *
- * Copyright (C) 2003-2004, 2017  Ossama Othman
+ * Copyright (C) 2003-2004, 2017-2018  Ossama Othman
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -74,8 +74,7 @@ namespace MaRC
          * averaging strategy will be applied in cases where multiple
          * images have data at the given longitude and latitude.
          *
-         * @param[in]  lat  Bodycentric (e.g. planetocentric) latitude
-         *                  in radians.
+         * @param[in]  lat  Planetocentric latitude in radians.
          * @param[in]  lon  Longitude in radians.
          * @param[out] data Data retrieved from image.
          *

--- a/lib/MaRC/Mu0Image.h
+++ b/lib/MaRC/Mu0Image.h
@@ -2,7 +2,7 @@
 /**
  * @file Mu0Image.h
  *
- * Copyright (C) 2003-2004, 2017  Ossama Othman
+ * Copyright (C) 2003-2004, 2017-2018  Ossama Othman
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -54,8 +54,8 @@ namespace MaRC
         /**
          * @param[in] body          Object representing the body being
          *                          mapped.
-         * @param[in] sub_solar_lat Bodycentric sub-solar latitude in
-         *                          degrees.
+         * @param[in] sub_solar_lat Planetocentric sub-solar latitude
+         *                          in degrees.
          * @param[in] sub_solar_lon Sub-solar longitude in degrees.
          * @param[in] scale         Linear scaling value by which
          *                          cosines will be multiplied.
@@ -84,7 +84,7 @@ namespace MaRC
         /// Object representing the body being mapped.
         std::shared_ptr<BodyData> const body_;
 
-        /// Bodycentric sub-solar latitude in radians.
+        /// Planetocentric sub-solar latitude in radians.
         const double sub_solar_lat_;
 
         /// Sub-solar longitude in radians.

--- a/lib/MaRC/Mu0Image.h
+++ b/lib/MaRC/Mu0Image.h
@@ -85,10 +85,10 @@ namespace MaRC
         std::shared_ptr<BodyData> const body_;
 
         /// Planetocentric sub-solar latitude in radians.
-        const double sub_solar_lat_;
+        double const sub_solar_lat_;
 
         /// Sub-solar longitude in radians.
-        const double sub_solar_lon_;
+        double const sub_solar_lon_;
 
     };
 

--- a/lib/MaRC/MuImage.h
+++ b/lib/MaRC/MuImage.h
@@ -2,7 +2,7 @@
 /**
  * @file MuImage.h
  *
- * Copyright (C) 2003-2004, 2017  Ossama Othman
+ * Copyright (C) 2003-2004, 2017-2018  Ossama Othman
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -52,8 +52,8 @@ namespace MaRC
         /**
          * @param[in] body           Object representing the body
          *                           being mapped.
-         * @param[in] sub_observ_lat Bodycentric sub-observer latitude
-         *                           in degrees.
+         * @param[in] sub_observ_lat Planetocentric sub-observer
+         *                           latitude in degrees.
          * @param[in] sub_observ_lon Sub-observer longitude in
          *                           degrees.
          * @param[in] range          Observer to target center
@@ -86,7 +86,7 @@ namespace MaRC
         /// Object representing the body being mapped.
         std::shared_ptr<BodyData> const body_;
 
-        /// Bodycentric sub-observer latitude in radians.
+        /// Planetocentric sub-observer latitude in radians.
         double const sub_observ_lat_;
 
         /// Sub-observer longitude in radians.

--- a/lib/MaRC/OblateSpheroid.cpp
+++ b/lib/MaRC/OblateSpheroid.cpp
@@ -1,7 +1,7 @@
 /**
  * @file OblateSpheroid.cpp
  *
- * Copyright (C) 1999, 2003-2004, 2017  Ossama Othman
+ * Copyright (C) 1999, 2003-2004, 2017-2018  Ossama Othman
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -62,7 +62,7 @@ double
 MaRC::OblateSpheroid::centric_radius(double lat) const
 {
     /*
-      Given a bodycentric latitude and longitude for a point (x, y, z)
+      Given a planetocentric latitude and longitude for a point (x, y, z)
       on the surface of a spheroid:
 
           x = r * cos(lat) * cos(lon)

--- a/lib/MaRC/OblateSpheroid.h
+++ b/lib/MaRC/OblateSpheroid.h
@@ -2,7 +2,7 @@
 /**
  * @file OblateSpheroid.h
  *
- * Copyright (C) 1999, 2003-2004, 2017  Ossama Othman
+ * Copyright (C) 1999, 2003-2004, 2017-2018  Ossama Othman
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -28,7 +28,6 @@
 #include <MaRC/BodyData.h>
 #include <MaRC/Vector.h>
 #include <MaRC/Export.h>
-
 
 
 namespace MaRC
@@ -125,7 +124,7 @@ namespace MaRC
 
         /// Radius of curvature of the meridian.
         /**
-         * @param[in] lat Bodycentric latitude
+         * @param[in] lat Planetocentric latitude.
          *
          * @return Radius of curvature of the meridian.
          */
@@ -134,7 +133,7 @@ namespace MaRC
         /// Radius of curvature in the direction of the prime vertical
         /// perpendicular to the direction of the meridian.
         /**
-         * @param[in] lat Bodycentric latitude
+         * @param[in] lat Planetocentric latitude.
          *
          * @return Radius of curvature in the direction of the prime
          *         vertical perpendicular to the direction of the
@@ -146,12 +145,10 @@ namespace MaRC
         /**
          * Line = vec + k * dvec, where k will computed.
          *
-         * @param[in]  vec  Vector from ellipsoid center to observer
-         * @param[in]  dvec Vector along line
-         * @param[out] lat  Bodycentric (e.g. planetocentric) latitude
-         *                  in radians
-         * @param[out] lon  Bodycentric (e.g. planetocentric) east
-         *                  longitude in radians
+         * @param[in]  vec  Vector from ellipsoid center to observer.
+         * @param[in]  dvec Vector along line.
+         * @param[out] lat  Planetocentric latitude in radians.
+         * @param[out] lon  Planetocentric east longitude in radians.
          *
          * @retval  0 ellipse intersection was found
          * @retval  1 no ellipse intersection was found

--- a/lib/MaRC/Orthographic.h
+++ b/lib/MaRC/Orthographic.h
@@ -63,7 +63,7 @@ namespace MaRC
         /**
          * @param[in] body           Pointer to @c OblateSpheroid
          *                           object representing body.
-         * @param[in] sub_observ_lat Bodycentric sub-observer latitude
+         * @param[in] sub_observ_lat Planetocentric sub-observer latitude
          *                           in degrees.
          * @param[in] sub_observ_lon Sub-observer longitude in
          *                           degrees.

--- a/lib/MaRC/PhotoImage.h
+++ b/lib/MaRC/PhotoImage.h
@@ -2,7 +2,7 @@
 /**
  * @file PhotoImage.h
  *
- * Copyright (C) 1999, 2003-2005, 2017  Ossama Othman
+ * Copyright (C) 1999, 2003-2005, 2017-2018  Ossama Othman
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -91,8 +91,7 @@ namespace MaRC
          * Retrieve data and weight from source image.  The configured
          * data interpolation strategy will be applied.
          *
-         * @param[in]     lat    Bodycentric (e.g. planetocentric)
-         *                       latitude in radians.
+         * @param[in]     lat    Planetocentric latitude in radians.
          * @param[in]     lon    Longitude in radians.
          * @param[out]    data   Data retrieved from image.
          * @param[in,out] weight Distance from pixel to closest edge

--- a/lib/MaRC/PolarStereographic.cpp
+++ b/lib/MaRC/PolarStereographic.cpp
@@ -85,7 +85,7 @@ namespace
      *                  representing body being mapped.
      * @param[in] coeff Coefficient used in the Polar
      *                  Stereographic radius 'rho'.
-     * @param[in] latg  Bodygraphic latitude.
+     * @param[in] latg  Planetographic latitude.
      *
      * @return Value of point on projection along a radial line
      *         (e.g. along a longitude line).
@@ -224,7 +224,7 @@ MaRC::PolarStereographic::plot_map(std::size_t samples,
              *       finding and improve accuracy.
              */
 
-            // bodyGRAPHIC latitude.
+            // PlanetoGRAPHIC latitude.
             double const latg =
                 MaRC::root_find(rho, ll, ul, map_equation);
 
@@ -232,7 +232,7 @@ MaRC::PolarStereographic::plot_map(std::size_t samples,
             //           << latg_guess << ", "
             //           << latg << ")\n";
 
-            // Convert to bodyCENTRIC latitude
+            // Convert to planetoCENTRIC latitude.
             double const lat =
                 this->body_->centric_latitude(this->north_pole_
                                               ? latg
@@ -273,7 +273,7 @@ MaRC::PolarStereographic::plot_grid(std::size_t samples,
          *      the projection here?
          */
 
-        // Convert to bodygraphic latitude
+        // Convert to planetographic latitude.
         double const nn = this->body_->graphic_latitude(n * C::degree);
 
         double const rho = this->stereo_rho(nn);
@@ -339,7 +339,7 @@ MaRC::PolarStereographic::plot_grid(std::size_t samples,
 double
 MaRC::PolarStereographic::distortion(double latg) const
 {
-    // Note that latitude is bodyGRAPHIC.
+    // Note that latitude is planetoGRAPHIC.
     return 1 + distortion_coeff_ * std::pow(this->stereo_rho(latg), 2);
 }
 

--- a/lib/MaRC/PolarStereographic.cpp
+++ b/lib/MaRC/PolarStereographic.cpp
@@ -136,7 +136,7 @@ MaRC::PolarStereographic::PolarStereographic(
     }
 }
 
-const char *
+char const *
 MaRC::PolarStereographic::projection_name() const
 {
     return "Polar Stereographic";

--- a/lib/MaRC/PolarStereographic.h
+++ b/lib/MaRC/PolarStereographic.h
@@ -60,9 +60,9 @@ namespace MaRC
         /**
          * @param[in] body       Pointer to @c OblateSpheroid object
          *                       representing body being mapped.
-         * @param[in] max_lat    Maximum bodyCENTRIC latitude to map
-         *                       in degrees.  For example, given a map
-         *                       with 50 samples and 25 lines,
+         * @param[in] max_lat    Maximum planetoCENTRIC latitude to
+         *                       map in degrees.  For example, given a
+         *                       map with 50 samples and 25 lines,
          *                       @a max_lat will be at the lower edge
          *                       of line 1 and the upper edge of line
          *                       25.
@@ -88,10 +88,11 @@ namespace MaRC
         virtual char const * projection_name() const;
         //@}
 
-        /// Scale distortion at given bodygraphic latitude @a latg on
-        /// map.
+        /// 
         /**
-         * @param[in] latg Bodygraphic latitude.
+         * @brief Scale distortion at given planetographic latitude
+         *        @a latg on map.
+         * @param[in] latg Planetographic latitude.
          */
         double distortion(double latg) const;
 
@@ -122,7 +123,7 @@ namespace MaRC
 
         /// The underlying Polar Stereographic projection equation.
         /**
-         * @param[in] latg Bodygraphic latitude.
+         * @param[in] latg Planetographic latitude.
          *
          * @return Value of point on projection along a radial line
          *         (e.g. along a longitude line).
@@ -135,7 +136,7 @@ namespace MaRC
         /// mapped.
         std::shared_ptr<OblateSpheroid> const body_;
 
-        /// Maximum bodyCENTRIC latitude to map in radians.
+        /// Maximum planetoCENTRIC latitude to map in radians.
         double const max_lat_;
 
         /// Coefficient used in map equation.

--- a/lib/MaRC/SimpleCylindrical.h
+++ b/lib/MaRC/SimpleCylindrical.h
@@ -61,16 +61,16 @@ namespace MaRC
         /**
          * @param[in] body        Pointer to @c BodyData object
          *                        representing body being mapped.
-         * @param[in] lo_lat      Bodycentric lower latitude in
+         * @param[in] lo_lat      Planetocentric lower latitude in
          *                        degrees in simple cylindrical map.
-         * @param[in] hi_lat      Bodycentric upper latitude in
+         * @param[in] hi_lat      Planetocentric upper latitude in
          *                        degrees in simple cylindrical map.
          * @param[in] lo_lon      Lower longitude in degrees in simple
          *                        cylindrical map.
          * @param[in] hi_lon      Upper longitude in degrees in simple
          *                        cylindrical map.
-         * @param[in] graphic_lat Map bodygraphic latitudes instead of
-         *                        bodycentric latitudes.
+         * @param[in] graphic_lat Map planetographic latitudes instead
+         *                        of planetocentric latitudes.
          */
         SimpleCylindrical(std::shared_ptr<BodyData> body,
                           double lo_lat,
@@ -157,8 +157,8 @@ namespace MaRC
         /// Upper longitude in simple cylindrical map.
         double hi_lon_;
 
-        /// Flag that determines if bodygraphic latitudes are mapped
-        /// instead of bodycentric latitudes.
+        /// Flag that determines if planetographic latitudes are
+        /// mapped instead of planetocentric latitudes.
         bool const graphic_lat_;
 
     };

--- a/lib/MaRC/SourceImage.h
+++ b/lib/MaRC/SourceImage.h
@@ -2,7 +2,7 @@
 /**
  * @file SourceImage.h
  *
- * Copyright (C) 1999, 2003-2004, 2017  Ossama Othman
+ * Copyright (C) 1999, 2003-2004, 2017-2018  Ossama Othman
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -58,8 +58,7 @@ namespace MaRC
         /**
          * Retrieve data from source image.
          *
-         * @param[in]  lat  Bodycentric (e.g. planetocentric) latitude
-         *                  in radians.
+         * @param[in]  lat  Planetocentric latitude in radians.
          * @param[in]  lon  Longitude in radians.
          * @param[out] data Data retrieved from image.
          *
@@ -79,8 +78,7 @@ namespace MaRC
          * override this method if they will provide a @a weight along
          * with @a data.
          *
-         * @param[in]     lat    Bodycentric (e.g. planetocentric)
-         *                       latitude in radians.
+         * @param[in]     lat    Planetocentric latitude in radians.
          * @param[in]     lon    Longitude in radians.
          * @param[out]    data   Data retrieved from image.
          * @param[in,out] weight Distance from pixel to closest edge

--- a/lib/MaRC/ViewingGeometry.h
+++ b/lib/MaRC/ViewingGeometry.h
@@ -2,7 +2,7 @@
 /**
  * @file ViewingGeometry.h
  *
- * Copyright (C) 1999, 2003-2005, 2017  Ossama Othman
+ * Copyright (C) 1999, 2003-2005, 2017-2018  Ossama Othman
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -285,8 +285,7 @@ namespace MaRC
 
         /// Convert (latitude, longitude) to (sample, line).
         /**
-         * @param[in]  lat Bodycentric (e.g. planetocentric) latitude
-         *                 in radians.
+         * @param[in]  lat Planetocentric latitude in radians.
          * @param[in]  lon Longitude in radians.
          * @param[out] x   Sample at given latitude and longitude.
          * @param[out] z   Line at given latitude and longitude.
@@ -313,8 +312,7 @@ namespace MaRC
         /**
          * @param[in]  sample Sample at given latitude and longitude.
          * @param[in]  line   Line at given latitude and longitude.
-         * @param[out] lat    Bodycentric (e.g. planetocentric)
-         *                    latitude in radians.
+         * @param[out] lat    Planetocentric latitude in radians.
          * @param[out] lon    Longitude in radians.
          *
          * @retval true  Conversion succeeded.
@@ -391,13 +389,13 @@ namespace MaRC
          */
         std::shared_ptr<OblateSpheroid> const body_;
 
-        /// Sub-Observer Latitude -- BodyCENTRIC (radians).
+        /// Sub-Observer Latitude -- Planetocentric (radians).
         double sub_observ_lat_;
 
         /// Sub-Observer Longitude -- Central Meridian (radians).
         double sub_observ_lon_;
 
-        /// Sub-Solar Latitude -- BodyCENTRIC (radians)
+        /// Sub-Solar Latitude -- Planetocentric (radians)
         double sub_solar_lat_;
 
         /// Sub-Solar Longitude (radians)
@@ -472,7 +470,7 @@ namespace MaRC
         double line_center_;
         //@}
 
-        /// BODYcentric latitude at picture center.
+        /// Planetocentric latitude at picture center.
         double lat_at_center_;
 
         /// Longitude at picture center

--- a/lib/MaRC/VirtualImage.h
+++ b/lib/MaRC/VirtualImage.h
@@ -2,7 +2,7 @@
 /**
  * @file VirtualImage.h
  *
- * Copyright (C) 2003-2004, 2017  Ossama Othman
+ * Copyright (C) 2003-2004, 2017-2018  Ossama Othman
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -283,8 +283,7 @@ namespace MaRC
          * transformations, if any.  Raw data is computed/retrieved
          * from the @c read_data_i() template method.
          *
-         * @param[in]  lat  Bodycentric (e.g. planetocentric) latitude
-         *                  in radians.
+         * @param[in]  lat  Planetocentric latitude in radians.
          * @param[in]  lon  Longitude in radians.
          *
          * @param[out] data Data retrieved from image.
@@ -359,8 +358,7 @@ namespace MaRC
          * This template method is the core implementation of the
          * @c read_data() method.
          *
-         * @param[in]  lat  Bodycentric (e.g. planetocentric) latitude
-         *                  in radians.
+         * @param[in]  lat  Planetocentric latitude in radians.
          * @param[in]  lon  Longitude in radians.
          *
          * @param[out] data Data retrieved from image.

--- a/src/CosPhaseImageFactory.h
+++ b/src/CosPhaseImageFactory.h
@@ -2,7 +2,7 @@
 /**
  * @file CosPhaseImageFactory.h
  *
- * Copyright (C) 2004, 2017  Ossama Othman
+ * Copyright (C) 2004, 2017-2018  Ossama Othman
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -47,11 +47,12 @@ namespace MaRC
         /// Constructor.
         /**
          * @param[in] body           Body being mapped.
-         * @param[in] sub_observ_lat Bodycentric sub-observer latitude
-         *                           in degrees.
+         * @param[in] sub_observ_lat Planetocentric sub-observer
+         *                           latitude  in degrees.
          * @param[in] sub_observ_lon Sub-observer longitude in
          *                           degrees.
-         * @param[in] sub_solar_lat  Sub-solar latitude in degrees.
+         * @param[in] sub_solar_lat  Planetocentric sub-solar latitude
+         *                           in degrees.
          * @param[in] sub_solar_lon  Sub-solar longitude in degrees.
          * @param[in] range          Observer to target center
          *                           distance.
@@ -72,13 +73,13 @@ namespace MaRC
         /// Object representing the body being mapped.
         std::shared_ptr<BodyData> const body_;
 
-        /// Sub-Observer Latitude -- BodyCENTRIC (degrees).
+        /// Sub-Observer Latitude -- PlanetoCENTRIC (degrees).
         double sub_observ_lat_;
 
         /// Sub-Observer Longitude -- Central Meridian (degrees).
         double sub_observ_lon_;
 
-        /// Sub-Solar Latitude -- BodyCENTRIC (degrees)
+        /// Sub-Solar Latitude -- PlanetoCENTRIC (degrees)
         double sub_solar_lat_;
 
         /// Sub-Solar Longitude (degrees)

--- a/src/LatitudeImageFactory.h
+++ b/src/LatitudeImageFactory.h
@@ -2,7 +2,7 @@
 /**
  * @file LatitudeImageFactory.h
  *
- * Copyright (C) 2004, 2017  Ossama Othman
+ * Copyright (C) 2004, 2017-2018  Ossama Othman
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -47,9 +47,9 @@ namespace MaRC
          * @param[in] body              Pointer to BodyData object
          *                              representing body being
          *                              mapped.
-         * @param[in] graphic_latitudes Return bodygraphic latitudes
-         *                              instead of bodycentric
-         *                              latitudes.
+         * @param[in] graphic_latitudes Return planetographic
+         *                              latitudes instead of
+         *                              planetocentric latitudes.
          */
         LatitudeImageFactory(std::shared_ptr<BodyData> body,
                              bool graphic_latitudes);
@@ -63,8 +63,8 @@ namespace MaRC
         /// Object representing the body being mapped.
         std::shared_ptr<BodyData> const body_;
 
-        /// Flag that determines if bodygraphic latitudes are returned
-        /// instead of bodycentric latitudes.
+        /// Flag that determines if planetographic latitudes are
+        /// returned instead of planetocentric latitudes.
         bool const graphic_latitudes_;
 
     };

--- a/src/Mu0ImageFactory.h
+++ b/src/Mu0ImageFactory.h
@@ -2,7 +2,7 @@
 /**
  * @file Mu0ImageFactory.h
  *
- * Copyright (C) 2004, 2017  Ossama Othman
+ * Copyright (C) 2004, 2017-2018  Ossama Othman
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -45,7 +45,8 @@ namespace MaRC
         /// Constructor.
         /**
          * @param[in] body          Body being mapped.
-         * @param[in] sub_solar_lat Sub-solar latitude in degrees.
+         * @param[in] sub_solar_lat Planetocentric sub-solar latitude
+         *                          in degrees.
          * @param[in] sub_solar_lon Sub-solar longitude in degrees.
          */
         Mu0ImageFactory(std::shared_ptr<BodyData> body,
@@ -61,7 +62,7 @@ namespace MaRC
         /// Object representing the body being mapped.
         std::shared_ptr<BodyData> const body_;
 
-        /// Sub-solar latitude (degrees).
+        /// Planetocentric sub-solar latitude (degrees).
         double sub_solar_lat_;
 
         /// Sub-solar longitude (degrees).

--- a/src/MuImageFactory.h
+++ b/src/MuImageFactory.h
@@ -2,7 +2,7 @@
 /**
  * @file MuImageFactory.h
  *
- * Copyright (C) 2004, 2017  Ossama Othman
+ * Copyright (C) 2004, 2017-2018  Ossama Othman
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -45,8 +45,8 @@ namespace MaRC
         /// Constructor.
         /**
          * @param[in] body           Body being mapped.
-         * @param[in] sub_observ_lat Bodycentric sub-observer latitude
-         *                           in degrees.
+         * @param[in] sub_observ_lat Planetocentric sub-observer
+         *                           latitude in degrees.
          * @param[in] sub_observ_lon Sub-observer longitude in
          *                           degrees.
          * @param[in] range          Observer to target center
@@ -66,7 +66,7 @@ namespace MaRC
         /// Object representing the body being mapped.
         std::shared_ptr<BodyData> const body_;
 
-        /// Sub-Observer Latitude -- BodyCENTRIC (degrees).
+        /// Sub-Observer Latitude -- PlanetoCENTRIC (degrees).
         double sub_observ_lat_;
 
         /// Sub-Observer Longitude -- Central Meridian (degrees).

--- a/src/marc.cpp
+++ b/src/marc.cpp
@@ -124,7 +124,7 @@ main(int argc, char *argv[])
 
         for (auto & p : commands)
             (void) p->execute();
-    } catch (const std::exception & e) {
+    } catch (std::exception const & e) {
         std::cerr << "MaRC: " << e.what() << std::endl;
         return -1;
     }

--- a/src/parse_scan.cpp
+++ b/src/parse_scan.cpp
@@ -114,9 +114,9 @@ MaRC::Radii::validate()
 // {
 //   FlexLexer & lexer = pp.lexer ();
 
-//   const int token = lexer.yylex ();
+//   int const token = lexer.yylex ();
 
-//   const char * symbuf = nullptr;
+//   char const * symbuf = nullptr;
 //   MaRC::sym_entry *s = nullptr;
 
 //   switch (token)

--- a/tests/LatitudeImage_Test.cpp
+++ b/tests/LatitudeImage_Test.cpp
@@ -1,7 +1,7 @@
 /**
  * @file LatitudeImage_Test.cpp
  *
- * Copyright (C) 2017 Ossama Othman
+ * Copyright (C) 2017-2018 Ossama Othman
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -77,7 +77,7 @@ bool test_latitude_image()
         std::make_shared<MaRC::OblateSpheroid>(prograde, eq_rad, pol_rad);
 
     /**
-     * @todo Test case when bodygraphic latitudes is requested.
+     * @todo Test case when planetographic latitudes is requested.
      */
     constexpr bool graphic_latitudes = false;
 

--- a/tests/Mercator_Test.cpp
+++ b/tests/Mercator_Test.cpp
@@ -40,8 +40,6 @@ namespace
     std::shared_ptr<MaRC::OblateSpheroid> body =
         std::make_shared<MaRC::OblateSpheroid>(prograde, eq_rad, pol_rad);
 
-    constexpr bool   north_pole = false;
-
     auto projection =
         std::make_unique<MaRC::Mercator>(body);
 

--- a/tests/Vector_Test.cpp
+++ b/tests/Vector_Test.cpp
@@ -115,7 +115,7 @@ bool test_vector_multiplication()
 {
     using vector_type = MaRC::Vector<int, 3>;
 
-    vector_type const   v1 {{ 2, 3,  5 }};
+    vector_type const v1 {{ 2, 3,  5 }};
 
     vector_type::value_type s = 2;
 
@@ -131,7 +131,7 @@ bool test_vector_multiplication()
 bool test_vector_magnitude()
 {
     using vector_type = MaRC::Vector<int, 3>;
-    vector_type  const v{ 3, 4, 5 };
+    vector_type const v{ 3, 4, 5 };
 
     double const mag =
         std::sqrt(v[0] * v[0] + v[1] * v[1] + v[2] * v[2]);


### PR DESCRIPTION
Replace all cases of the MaRC-specific "bodycentric" and "bodygraphic" with NASA NAIF recommended "planetocentric" and "planetographic", respectively.   Fixes #68.

