### PR TITLE
Move MaRC configuration file to $XDG_CONFIG_HOME/marc.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,8 @@
+- The user-specific MaRC configuration file is now expected to be
+  `$XDG_CONFIG_HOME/marc', which is `~/.config/marc' by default, to
+  conform to the XDG Base Directory Specification.  The old MaRC
+  configuration filename `~/.marc' is no longer supported.
+
 - Added command line option support.  Try "marc --help".
 
 - Improved logging by leveraging the spdlog library as the underling

--- a/configure.ac
+++ b/configure.ac
@@ -88,10 +88,17 @@ dnl
 
 dnl Text to be placed at the top of the `MaRC/config.h' header.
 AH_TOP([
+/**
+ * @file config.h
+ *
+ * MaRC configuration header file.
+ *
+ * @note This is an internal header, and not meant for use
+ *       outside of MaRC.
+ */
 #ifndef MARC_CONFIG_H
 #define MARC_CONFIG_H
 
-// MaRC configuration header file
 ])
 
 dnl Text to be placed at the bottom of the `MaRC/config.h' header.

--- a/doc/MaRC_input.texi
+++ b/doc/MaRC_input.texi
@@ -29,7 +29,7 @@ Free Documentation License".
 
 @titlepage
 @title MaRC Input Files
-@subtitle Creation of Input and User Defaults Files
+@subtitle Creation of Input and User Configuration Files
 @subtitle Edition @value{EDITION}
 @subtitle @value{UPDATED-MONTH}
 @author Ossama Othman
@@ -52,13 +52,13 @@ Free Documentation License".
 @end ifnottex
 
 @menu
-* Overview::              The form and purpose of a MaRC input
-                          file and the user defaults file.
-* Input Files::           This chapter described how to create
-                          and setup a MaRC input file.
-* User Defaults Files::   This chapter describes hot to create
-                          and setup a MaRC user defaults file.
-* Copying This Manual::   How to make copies of this manual.
+* Overview::                  The form and purpose of a MaRC input
+                              file and the user configuration file.
+* Input Files::               This chapter described how to create
+                              and setup a MaRC input file.
+* User Configuration File::   This chapter describes how to structure
+                              a MaRC user configuration file.
+* Copying This Manual::       How to make copies of this manual.
 * Concept Index::
 @end menu
 
@@ -94,14 +94,15 @@ Map Size
 Map Plane Information
 @end itemize
 
-The user defaults file allows the user to set standard values for all
-maps, planes and input images.  The form of the information entered into
-this file is much simpler than that of the input file.  However, the
-detailed descriptions of the information entered into the user defaults
-file can be found in the input files section since entries in the user
-defaults file have much in common with their input file counterparts.
+The user configuration file allows the user to set standard values for
+all maps, planes and input images.  The form of the information
+entered into this file is much simpler than that of the input file.
+However, the detailed descriptions of the information entered into the
+user configuration file can be found in the input files section since
+entries in the user configuration file have much in common with their
+input file counterparts.
 
-@node    Input Files,  User Defaults Files, Overview,    Top
+@node    Input Files,  User Configuration File, Overview,    Top
 @comment node-name,     next,           previous, up
 
 @cindex Input Files
@@ -2298,26 +2299,29 @@ XCOMMENT:Latitude / Longitude grid for primary array (the cube)
                 LONGITUDE
 @end example
 
-@node    User Defaults Files,   Copying This Manual,  Input Files,    Top
+@node    User Configuration File,   Copying This Manual,  Input Files,    Top
 @comment node-name,     next,           previous, up
-@chapter User Defaults Files
-@cindex User Defaults Files
-@cindex .marc user defaults file
-Sometimes all maps in a given input file have the same options.  Setting
-the same option for each map or image can be tedious.  Instead, the user
-can define default values for all maps and input images.  At startup,
-MaRC searches for a file called @file{.marc} in the users home
-directory.  This file contains user defined defaults for the grid
-interval size, the valid data range for each plane and the nibbling
-values for all input images.  If set, than these values will be applied
-to all maps and input images.  However, it is possible to override these
-values by entering a different value in the input file where
-appropriate, as explained the MaRC Input File section.  Any map, plane
-or image entry that does not override the values in the user defaults
-file will use the values found in the user defaults file.  If a value is
-not set in the user defaults file, then the MaRC internal defaults will
-be used.  All entries in the user defaults file are optional, but must
-follow a specific order if used:
+@chapter User Configuration File
+@cindex User Configuration File
+@cindex .marc user configuration file
+Sometimes all maps in a given input file have the same options.
+Setting the same option for each map or image can be tedious.
+Instead, the user can define default values for all maps and input
+images.  At startup, MaRC searches for a file
+@file{$XDG_CONFIG_HOME/marc}, which defaults to @file{~/.config/marc}
+if the @file{$XDG_CONFIG_HOME} environment variable is not set.  This
+file contains the user-specific MaRC configuration settings for the
+grid interval size, the valid data range for each plane and the
+nibbling values for all input images.  If set, than these values will
+be applied to all maps and input images.  However, it is possible to
+override these values by entering a different value in the input file
+where appropriate, as explained the MaRC Input File section.  Any map,
+plane or image entry that does not override the values in the user
+configuration file will use the values found in the user configuration
+file.  If a value is not set in the user configuration file, then the
+MaRC internal defaults will be used.  All entries in the user
+configuration file are optional, but must follow a specific order if
+used:
 
 @example
 GRID_INTERVAL:  10      # Must be before the data range and nibbling.
@@ -2331,10 +2335,10 @@ NIBBLE_BOTTOM:  8
 
 @noindent
 If it is not necessary, for example, to set @code{DATA_MIN} and
-@code{NIBBLE_RIGHT}, then simply remove them from the user defaults
-file, since all of these entries are optional.
+@code{NIBBLE_RIGHT}, then simply remove them from the user
+configuration file, since all of these entries are optional.
 
-@node    Copying This Manual,   Concept Index,  User Defaults Files,    Top
+@node    Copying This Manual,   Concept Index,  User Configuration File,    Top
 @comment node-name,     next,           previous, up
 @appendix Copying This Manual
 @cindex copying

--- a/doc/marc.1
+++ b/doc/marc.1
@@ -10,7 +10,7 @@
 .\" Process this file with
 .\" groff -man -Tascii marc.1
 .\"
-.TH MARC 1 "2018-07-02" "MaRC" "User Commands"
+.TH MARC 1 "2018-07-12" "MaRC" "User Commands"
 .SH NAME
 marc \- create digital map projections
 .SH SYNOPSIS
@@ -64,8 +64,12 @@ print program version
 
 .SH FILES
 .TP
-.I ~/.marc
-User configuration file. See the
+.I $XDG_CONFIG_HOME/marc
+User configuration file, which defaults to
+.I ~/.config/marc
+if
+.I $XDG_CONFIG_HOME
+is not set.  See the
 .B MaRC_input
 manual for further details.
 

--- a/lib/MaRC/Log.h
+++ b/lib/MaRC/Log.h
@@ -57,6 +57,11 @@
 
 namespace MaRC
 {
+    /**
+     * @typedef Underlying logger type.
+     *
+     * @note Not meant for use outside of MaRC.
+     */
     using logger_type = std::shared_ptr<spdlog::logger>;
 
     /**
@@ -65,12 +70,17 @@ namespace MaRC
      * @todo This isn't a good way to expose the MaRC logger
      *       instance since it isn't meant to be part of the MaRC
      *       API.
-     *
-     * @attention Not to be confused with @c std::log()!
-     *
      */
     extern MARC_API logger_type const _logger;
 
+    /**
+     * @brief Log debugging messages.
+     *
+     * @param[in] args Log arguments formatted according to the @c fmt
+     *                 library.
+     *
+     * @see http://fmtlib.net/latest/index.html
+     */
     template <typename ... Args>
     void
     debug(Args const & ... MARC_DEBUG_ARGS(args))
@@ -78,6 +88,14 @@ namespace MaRC
         SPDLOG_DEBUG(_logger, args ...);
     }
 
+    /**
+     * @brief Log information messages.
+     *
+     * @param[in] args Log arguments formatted according to the @c fmt
+     *                 library.
+     *
+     * @see http://fmtlib.net/latest/index.html
+     */
     template <typename ... Args>
     void
     info(Args const & ... args)
@@ -85,6 +103,14 @@ namespace MaRC
         _logger->info(args ...);
     }
 
+    /**
+     * @brief Log warning messages.
+     *
+     * @param[in] args Log arguments formatted according to the @c fmt
+     *                 library.
+     *
+     * @see http://fmtlib.net/latest/index.html
+     */
     template <typename ... Args>
     void
     warn(Args const & ... args)
@@ -92,6 +118,14 @@ namespace MaRC
         _logger->warn(args ...);
     }
 
+    /**
+     * @brief Log error messages.
+     *
+     * @param[in] args Log arguments formatted according to the @c fmt
+     *                 library.
+     *
+     * @see http://fmtlib.net/latest/index.html
+     */
     template <typename ... Args>
     void
     error(Args const & ... args)
@@ -99,6 +133,14 @@ namespace MaRC
         _logger->error(args ...);
     }
 
+    /**
+     * @brief Log critical messages.
+     *
+     * @param[in] args Log arguments formatted according to the @c fmt
+     *                 library.
+     *
+     * @see http://fmtlib.net/latest/index.html
+     */
     template <typename ... Args>
     void
     critical(Args const & ... args)

--- a/lib/MaRC/PhotoImageParameters.h
+++ b/lib/MaRC/PhotoImageParameters.h
@@ -1,6 +1,6 @@
 //   -*- C++ -*-
 /**
- * @file PhotoImage.h
+ * @file PhotoImageParameters.h
  *
  * Copyright (C) 1999, 2003-2005, 2017  Ossama Othman
  *

--- a/lib/MaRC/Vector.h
+++ b/lib/MaRC/Vector.h
@@ -313,6 +313,8 @@ namespace MaRC
      *            calculated.
      *
      * @return Magnitude of vector @a v.
+     *
+     * @relates MaRC::Vector
      */
     template <typename T, std::size_t M>
     auto magnitude(Vector<T, M> const & v)
@@ -338,6 +340,8 @@ namespace MaRC
      *            calculated.
      *
      * @return Magnitude of vector @a v.
+     *
+     * @relates MaRC::Vector
      */
     template <typename T>
     auto magnitude(Vector<T, 3> const & v)
@@ -354,6 +358,8 @@ namespace MaRC
      *            calculated.
      *
      * @return Magnitude of vector @a v.
+     *
+     * @relates MaRC::Vector
      */
     template <typename T>
     auto magnitude(Vector<T, 2> const & v)
@@ -370,8 +376,9 @@ namespace MaRC
      *            calculated.
      *
      * @return Magnitude of vector @a v.
+     *
+     * @relates MaRC::Vector
      */
-
     template <typename T>
     auto magnitude(Vector<T, 1> const & v)
     {
@@ -385,6 +392,8 @@ namespace MaRC
      * @attention This function requires that the vector @a v contain
      *            floating point values since it is not possible to
      *            store fractional values in an integer.
+     *
+     * @relates MaRC::Vector
      */
     template <typename T, std::size_t M>
     void to_unit_vector(Vector<T, M> & v)
@@ -407,6 +416,8 @@ namespace MaRC
      * @param[in] b Second vector operand.
      *
      * @return Dot product of vectors @a a and @a b.
+     *
+     * @relates MaRC::Vector
      */
     template <typename T, std::size_t M>
     auto dot_product(Vector<T, M> const & a,
@@ -422,7 +433,11 @@ namespace MaRC
 
 // ---------------------------------------------------------
 
-/// Vector addition operator.
+/**
+ * @brief Vector addition operator.
+ *
+ * @relates MaRC::Vector
+ */
 template <typename T, std::size_t M>
 MaRC::Vector<T, M> const operator+(MaRC::Vector<T, M> const & lhs,
                                    MaRC::Vector<T, M> const & rhs)
@@ -433,7 +448,11 @@ MaRC::Vector<T, M> const operator+(MaRC::Vector<T, M> const & lhs,
     return vector;
 }
 
-/// Vector subtraction operator
+/**
+ * @brief Vector subtraction operator
+ *
+ * @relates MaRC::Vector
+ */
 template <typename T, std::size_t M>
 MaRC::Vector<T, M> const operator-(MaRC::Vector<T, M> const & lhs,
                                    MaRC::Vector<T, M> const & rhs)
@@ -444,7 +463,11 @@ MaRC::Vector<T, M> const operator-(MaRC::Vector<T, M> const & lhs,
     return vector;
 }
 
-/// Vector/scalar multiplication operator
+/**
+ * Vector/scalar multiplication operator
+ *
+ * @relates MaRC::Vector
+ */
 template <typename T, std::size_t M>
 MaRC::Vector<T, M> const operator*(MaRC::Vector<T, M> const & V,
                                    T x)
@@ -455,7 +478,11 @@ MaRC::Vector<T, M> const operator*(MaRC::Vector<T, M> const & V,
     return vector;
 }
 
-/// Vector/scalar multiplication operator
+/**
+ * Vector/scalar multiplication operator
+ *
+ * @relates MaRC::Vector
+ */
 template <typename T, std::size_t M>
 MaRC::Vector<T, M> const operator*(T x,
                                    MaRC::Vector<T, M> const & V)
@@ -465,7 +492,11 @@ MaRC::Vector<T, M> const operator*(T x,
 
 // ---------------------------------------------------------
 
-/// Vector equality operator.
+/**
+ * @brief Vector equality operator.
+ *
+ * @relates MaRC::Vector
+ */
 template <typename T, std::size_t M>
 bool operator==(MaRC::Vector<T, M> const & lhs,
                 MaRC::Vector<T, M> const & rhs)
@@ -478,7 +509,11 @@ bool operator==(MaRC::Vector<T, M> const & lhs,
                       rhs.begin(), rhs.end());
 }
 
-/// Vector inequality operator.
+/**
+ * @brief Vector inequality operator.
+ *
+ * @relates MaRC::Vector
+ */
 template <typename T, std::size_t M>
 bool operator!=(MaRC::Vector<T, M> const & lhs,
                 MaRC::Vector<T, M> const & rhs)
@@ -488,7 +523,11 @@ bool operator!=(MaRC::Vector<T, M> const & lhs,
 
 // ---------------------------------------------------------
 
-/// Stream insertion operator
+/**
+ * @brief Stream insertion operator
+ *
+ * @relates MaRC::Vector
+ */
 template <typename T, std::size_t M>
 std::ostream & operator<<(std::ostream & s, MaRC::Vector<T, M> const & v)
 {

--- a/lib/MaRC/VirtualImage.h
+++ b/lib/MaRC/VirtualImage.h
@@ -44,8 +44,7 @@ namespace MaRC
      *
      * @see MaRC::scale_and_offset()
      *
-     * @internal This functor is not part of the public MaRC library
-     *           API.
+     * @note This functor is not part of the public MaRC library API.
      */
     template <typename T>
     struct scale_and_offset_impl
@@ -111,7 +110,7 @@ namespace MaRC
      *
      * @see MaRC::scale_and_offset()
      *
-     * @internal This functor is not part of public MaRC library API.
+     * @note This functor is not part of the public MaRC library API.
      */
     template <>
     struct scale_and_offset_impl<float>
@@ -140,7 +139,7 @@ namespace MaRC
      *
      * @see MaRC::scale_and_offset()
      *
-     * @internal This functor is not part of public MaRC library API.
+     * @note This functor is not part of the public MaRC library API.
      */
     template <>
     struct scale_and_offset_impl<double>

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -74,7 +74,8 @@ noinst_HEADERS = \
   FITS_traits.h \
   calc.h \
   command_line.h \
-  parse_scan.h
+  parse_scan.h \
+  lexer.hh
 
 BUILT_SOURCES = parse.hh lexer.hh
 lexer.hh: lexer.cc

--- a/src/marc.cpp
+++ b/src/marc.cpp
@@ -278,7 +278,7 @@ int main(int argc, char *argv[])
     try {
         MaRC::ParseParameter parse_parameter;
 
-        std::string config_file(MaRC::get_config_filename());
+        std::string const config_file(MaRC::get_config_filename());
 
         MaRC::parse_file(config_file.c_str(), parse_parameter);
 

--- a/src/marc.cpp
+++ b/src/marc.cpp
@@ -242,24 +242,38 @@ namespace MaRC
      */
     std::string get_config_filename()
     {
+        // Get XDG Base Directory Specification conforming
+        // configuration file.
         std::string filename;
 
         char const * const config_dir = std::getenv("XDG_CONFIG_HOME");
+        char const * const home_dir   = std::getenv("HOME");
 
         if (config_dir != nullptr) {
             filename = std::string(config_dir) + "/" PACKAGE;
         } else {
-            char const * const home_dir = std::getenv("HOME");
+            if (home_dir == nullptr)
+                return filename;  // No home directory!
 
             constexpr char const tmp[] = "/.config/" PACKAGE;
 
-            if (home_dir != nullptr)
-                filename = std::string(home_dir);
-            else
-                filename = '~';
-
-            filename += tmp;
+            filename = std::string(home_dir) + tmp;
         }
+
+        // -----------------------------------------------------
+        // Warn of existence of old configuration file.
+        // -----------------------------------------------------
+        if (home_dir != nullptr) {
+            std::string const old_config =
+                std::string(home_dir) + "/.marc";
+
+            if (access(old_config.c_str(), F_OK) == 0) {
+                MaRC::warn("old configuration file `{}' exists",
+                           old_config);
+                MaRC::warn("expected: `{}'.", filename);
+            }
+        }
+        // -----------------------------------------------------
 
         return filename;
     }

--- a/tests/MaRC_Prog_Test.sh
+++ b/tests/MaRC_Prog_Test.sh
@@ -12,4 +12,6 @@ if test -z "${top_srcdir+set}"; then
   top_srcdir=..
 fi
 
-$top_builddir/src/marc $top_srcdir/tests/test_map.marc
+
+XDG_CONFIG_HOME=$top_srcdir/tests/config \
+    $top_builddir/src/marc $top_srcdir/tests/test_map.marc

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -118,6 +118,10 @@ CLEANFILES = \
   test_map.fits \
   test_map2.fits \
   test_map3.fits \
+  test_map4.fits \
+  test_map5.fits \
+  test_map6.fits \
+  test_map7.fits \
   test_map_ortho.fits \
   test_map_mercator.fits \
   test_map_polar_stereographic.fits

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -43,6 +43,7 @@ check_PROGRAMS =            \
 dist_check_SCRIPTS = MaRC_Prog_Test.sh command_line_test.sh
 
 dist_check_DATA = \
+  config/marc \
   test_map.marc \
   test.fits.gz
 

--- a/tests/config/marc
+++ b/tests/config/marc
@@ -1,0 +1,10 @@
+# This is a test file used to exercise the MaRC user configuration
+# file parsing code.
+
+GRID_INTERVAL:  10      # Must be before the data range and nibbling.
+DATA_MIN:      -10000   # Both before the nibbling entries.
+DATA_MAX:       10000
+NIBBLE_LEFT:    6       # These must used in the shown order.
+NIBBLE_RIGHT:   20
+NIBBLE_TOP:     8
+NIBBLE_BOTTOM:  8


### PR DESCRIPTION
Modern program conventions suggest placing user-specific configuration files `$XDG_CONFIG_HOME/<program>`, e.g. `~/.config/marc`, as defined in the [XDG Base Directory Specification](https://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html).  Make MaRC conform to that specification.  Fixes #77.