### PR TITLE
Fix artifacts in the orthographic projection

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,7 @@
+- Fixed a regression in quadratic roots calculations that caused some
+  areas of an Orthographic projection to incorrectly have data of
+  value zero, as well as other coordinate calculations.
+
 - Blank areas of integer typed maps now contain the user-supplied
   DATA_BLANK value, if specified in the MaRC input file.  This allows
   FITS image readers to easily identify areas of integer typed maps

--- a/lib/marc/Mathematics.h
+++ b/lib/marc/Mathematics.h
@@ -227,10 +227,34 @@ namespace MaRC
         if (discriminant < 0)
             return false;  // Roots are not real.
 
-        double const q = -(b + signum(b) * std::sqrt(discriminant)) / 2;
+        /**
+         * @todo Can we achieve the same affect without a branch?
+         */
+        if (b == 0) {
+            /*
+              signum(0) == 0 so we can't use the stable form of the
+              quadratic formula below but we can easily solve for x
+              when b is zero:
 
-        roots.first  = q / a;
-        roots.second = c / q;
+                       2
+                     ax  + c = 0
+
+              meaning the roots are:
+
+                     x = -sqrt(-c / a) and x = +sqrt(-c / a)
+
+              since both satisfy the above quadratic equation without
+              the "b" term.
+            */
+            roots.first  = std::sqrt(-c / a);
+            roots.second = -roots.first;
+        } else {
+            double const q =
+                -(b + signum(b) * std::sqrt(discriminant)) / 2;
+
+            roots.first  = q / a;
+            roots.second = c / q;
+        }
 
         return true;
     }

--- a/lib/marc/Orthographic.cpp
+++ b/lib/marc/Orthographic.cpp
@@ -206,7 +206,14 @@ MaRC::Orthographic::plot_map(std::size_t samples,
 
     double const a2   = this->body_->eq_rad() * this->body_->eq_rad();
     double const c2   = this->body_->pol_rad() * this->body_->pol_rad();
-    double const diff = a2 - c2;
+
+    /*
+      Reduce cancellation due to subtraction from being catastrophic
+      to benign by using the form (a-c)(a+c) instead of (a*a - c*c).
+     */
+    double const diff =
+        (this->body_->eq_rad() - this->body_->pol_rad())
+        * (this->body_->eq_rad() + this->body_->pol_rad());
 
     // "a" coefficient of the Quadratic Formula.
     double const CA =

--- a/lib/marc/plot_info.h
+++ b/lib/marc/plot_info.h
@@ -55,7 +55,10 @@ namespace MaRC
         using blank_type = MaRC::optional<std::intmax_t>;
 
         /**
-         * @brief Constructor
+         * @brief Constructor for integer blank types.
+         *
+         * Constructor used when supplying an integer typed @a blank
+         * value.
          *
          * @param[in] source   @c SourceImage object containing the
          *                     data to be mapped.
@@ -70,14 +73,79 @@ namespace MaRC
          *                     corresponds to undefined "blank"
          *                     physical values.
          */
+        template <typename T>
         plot_info(SourceImage const & source,
                   double minimum,
                   double maximum,
-                  blank_type blank = MaRC::nullopt)
+                  T blank)
             : source_(source)
             , minimum_(minimum)
             , maximum_(maximum)
             , blank_(blank)
+            , notifier_()
+        {
+        }
+
+        /**
+         * @brief Constructor for floating point blank types.
+         *
+         * Constructor used when supplying a floating point typed
+         * @a blank value.  In this case, the floating point value is
+         * actually ignored since the @c NaN constant is expected to
+         * be used as the blank value in %MaRC generated floating
+         * point typed map projections.
+         *
+         * This constructor exists to prevent implicit conversions
+         * from a floating point blank value to the integer based
+         * @c blank_type used by this class.  For example, this
+         * constructor prevents attempts to assign
+         * std::numeric_limits<float>::lowest() as the blank
+         * value since that would result in an overflow.
+         *
+         * @param[in] source   @c SourceImage object containing the
+         *                     data to be mapped.
+         * @param[in] minimum  Minimum allowed physical data value on
+         *                     map, i.e. all data greater than or
+         *                     equal to @a minimum.
+         * @param[in] maximum  Maximum allowed physical data value on
+         *                     map, i.e. all data less than or equal
+         *                     to @a maximum.
+         */
+        plot_info(SourceImage const & source,
+                  double minimum,
+                  double maximum,
+                  double /* unused */)
+            : source_(source)
+            , minimum_(minimum)
+            , maximum_(maximum)
+            , blank_()
+            , notifier_()
+        {
+        }
+
+        /**
+         * @brief Constructor used when no blank value is provided.
+         *
+         * By default, %MaRC will use @c 0 as the blank value for
+         * integer typed maps, and always use %c NaN for floating
+         * point typed maps.
+         *
+         * @param[in] source   @c SourceImage object containing the
+         *                     data to be mapped.
+         * @param[in] minimum  Minimum allowed physical data value on
+         *                     map, i.e. all data greater than or
+         *                     equal to @a minimum.
+         * @param[in] maximum  Maximum allowed physical data value on
+         *                     map, i.e. all data less than or equal
+         *                     to @a maximum.
+         */
+        plot_info(SourceImage const & source,
+                  double minimum,
+                  double maximum)
+            : source_(source)
+            , minimum_(minimum)
+            , maximum_(maximum)
+            , blank_()
             , notifier_()
         {
         }

--- a/tests/Math_Test.cpp
+++ b/tests/Math_Test.cpp
@@ -23,6 +23,58 @@
 #include <cstdint>
 
 
+namespace
+{
+    /**
+     * @brief Calculate and verify quadratic roots.
+     *
+     * @param[in] a              "a" coefficient of a quadratic
+     *                           equation.
+     * @param[in] b              "b" coefficient of a quadratic
+     *                           equation.
+     * @param[in] c              "c" coefficient of a quadratic
+     *                           equation.
+     * @param[in] expected_roots Quadratic roots that should be
+     *                           returned from
+     *                           MaRC::quadratic_roots().
+     *
+     * @return @c true on successful quadratic root validation, and
+     *         @c false otherwise
+     */
+    bool check_roots(double a,
+                     double b,
+                     double c,
+                     std::pair<double, double> expected_roots)
+    {
+        std::pair<double, double> roots;
+
+        /**
+         * @todo Verify this ULP value isn't too small.
+         *
+         * @see The blog post "Comparing Floating Point Numbers, 2012
+         *      Edition" for an additional discussion on floating
+         *      point comparison:
+         *      https://randomascii.wordpress.com/2012/02/25/comparing-floating-point-numbers-2012-edition/
+         */
+        static constexpr int ulp = 1;  // Units in the last place.
+
+        return
+            MaRC::quadratic_roots(a, b, c, roots) // found real roots
+            && ((MaRC::almost_equal(roots.first,
+                                    expected_roots.first,
+                                    ulp)
+                 && MaRC::almost_equal(roots.second,
+                                       expected_roots.second,
+                                       ulp))
+                || (MaRC::almost_equal(roots.first,
+                                       expected_roots.second,
+                                       ulp)
+                    && MaRC::almost_equal(roots.second,
+                                          expected_roots.first,
+                                          ulp)));
+    }
+}
+
 /**
  * @test Test the MaRC::almost_equal() function.
  */
@@ -132,40 +184,37 @@ bool test_quadratic_roots()
            b =  1
            c = -6
 
-      Solve using MaRC::quadratic_roots() and confirm we get the
-      expected roots.
+      Similarly, for a quadratic equation with roots (-2.5, 2.5) we
+      could have the following:
+
+          (2x + 5)(2x - 5) = 0
+
+      which in its polynomial form is:
+
+              2
+            4x  - 25 = 0
+
+      where its polynomial coefficients are:
+
+           a =   4
+           b =   0
+           c = -25
+
+      Solve both equations using MaRC::quadratic_roots(), and confirm
+      we get the expected roots.
     */
-    static constexpr int const a =  1;
-    static constexpr int const b =  1;
-    static constexpr int const c = -6;
-    static constexpr auto expected_roots = std::make_pair(-3.0, 2.0);
+    static constexpr int const a1 =  1;
+    static constexpr int const b1 =  1;
+    static constexpr int const c1 = -6;
+    static constexpr auto expected_roots1 = std::make_pair(-3.0, 2.0);
 
-    std::pair<double, double> roots;
+    static constexpr int const a2 =  4;
+    static constexpr int const b2 =  0;
+    static constexpr int const c2 = -25;
+    static constexpr auto expected_roots2 = std::make_pair(-2.5, 2.5);
 
-    /**
-     * @todo Verify this ULP value isn't too small.
-     *
-     * @see The blog post "Comparing Floating Point Numbers, 2012
-     *      Edition" for an additional discussion on floating point
-     *      comparison:
-     *      https://randomascii.wordpress.com/2012/02/25/comparing-floating-point-numbers-2012-edition/
-     */
-    static constexpr int ulp = 1;  // Units in the last place.
-
-    return
-        MaRC::quadratic_roots(a, b, c, roots) // found real roots
-        && ((MaRC::almost_equal(roots.first,
-                                expected_roots.first,
-                                ulp)
-             && MaRC::almost_equal(roots.second,
-                                   expected_roots.second,
-                                   ulp))
-            || (MaRC::almost_equal(roots.first,
-                                   expected_roots.second,
-                                   ulp)
-                && MaRC::almost_equal(roots.second,
-                                      expected_roots.first,
-                                      ulp)));
+    return check_roots(a1, b1, c1, expected_roots1)
+        && check_roots(a2, b2, c2, expected_roots2);
 }
 
 /// The canonical main entry point.


### PR DESCRIPTION
Unexpected values of zero were plotted along the center of body in orthographic projections with odd size map dimensions.  The problem was caused by a regression the `MaRC::quadratic_roots()` function when the _b_ coefficient of the quadratic equation being solved was zero.  The numerically stable form of the quadratic formula used in `MaRC::quadratic_roots()` uses the sign (signum) of the _b_ coefficient.  However, `signum(0)` is zero.  That caused incorrect calculation of the roots, i.e. (0, &infin;).  Special handling for the case where _b_ is zero was added.

The fix to `MaRC::quadratic_roots()` also corrects potential issues in  pixel-to-latitude/longitude conversion through `MaRC::OblateSpheroid::ellipse_intersection()`, and coordinate transformation calculations in `MaRC::ViewingGeometry::rot_matrices()`.

Precision in the orthographic projection was also improved by addressing a potential catastrophic cancellation prone subtraction.  For example, (a<sup>2</sup> - c<sup>2</sup>) is now (a - c)(a + c), where the cancellation due to subtraction in the latter form is benign.