### PR TITLE
Add pkg-config support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,9 @@ doc/mdate-sh
 doc/texinfo.tex
 doc/version.texi
 
+# pkg-config Files
+lib/marc/marc.pc
+
 # Documentation
 README
 doc/*.t2p/

--- a/configure.ac
+++ b/configure.ac
@@ -248,6 +248,7 @@ AC_CONFIG_FILES([
   doc/Makefile
   lib/Makefile
   lib/marc/Makefile
+  lib/marc/marc.pc
   src/Makefile
   tests/Makefile
 ])

--- a/lib/marc/Makefile.am
+++ b/lib/marc/Makefile.am
@@ -138,4 +138,7 @@ nobase_pkginclude_HEADERS = \
 
 # noinst_HEADERS =
 
+pkgconfigdir = $(libdir)/pkgconfig
+pkgconfig_DATA = marc.pc
+
 clean-local: code-coverage-clean

--- a/lib/marc/marc.pc.in
+++ b/lib/marc/marc.pc.in
@@ -1,0 +1,13 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: @PACKAGE_NAME@
+Description: The MaRC library
+URL: @PACKAGE_URL@
+Version: @VERSION@
+Requires.private: cfitsio
+Cflags: -I${includedir}
+Libs: -L${libdir} -lmarc
+Libs.private: @LIBS@

--- a/lib/marc/marc.pc.in
+++ b/lib/marc/marc.pc.in
@@ -7,7 +7,5 @@ Name: @PACKAGE_NAME@
 Description: The MaRC library
 URL: @PACKAGE_URL@
 Version: @VERSION@
-Requires.private: cfitsio
 Cflags: -I${includedir}
 Libs: -L${libdir} -lmarc
-Libs.private: @LIBS@


### PR DESCRIPTION
Generate a `marc.pc' [pkg-config](https://www.freedesktop.org/wiki/Software/pkg-config/) file that may be used by MaRC library
users to obtain the necessary build related information.