### PR TITLE
travis.yml: Use homebrew addon for MacOS build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,12 +35,12 @@ matrix:
       compiler: clang
       addons:
         homebrew:
-	  packages:
-	  - bison
-	  - flex
-	  - texinfo
-	  - autoconf-archive
-	  - fmt
+          packages:
+          - bison
+          - flex
+          - texinfo
+          - autoconf-archive
+          - fmt
 
 before_script:
     - ./bootstrap


### PR DESCRIPTION
The MacOS build on Travis-CI terminates early due to an excessively
long build log.  Drop the "brew update", and leverage the "homebrew"
Travis-CI addon in an effort to reduce the build log size.