### PR TITLE
Add MaRC matrix and vector formatters.

### DIFF
--- a/lib/marc/Makefile.am
+++ b/lib/marc/Makefile.am
@@ -72,6 +72,8 @@ nobase_pkginclude_HEADERS = \
   Mathematics.h   \
   Matrix.h \
   Vector.h \
+  matrix_formatter.h \
+  vector_formatter.h \
   \
   Geometry.h \
   \

--- a/lib/marc/Matrix.h
+++ b/lib/marc/Matrix.h
@@ -4,7 +4,7 @@
  *
  * %MaRC matrix class and operations.
  *
- * Copyright (C) 2004, 2017-2018  Ossama Othman
+ * Copyright (C) 2004, 2017-2018, 2021  Ossama Othman
  *
  * SPDX-License-Identifier: LGPL-2.1-or-later
  *
@@ -473,30 +473,6 @@ bool operator!=(MaRC::Matrix<T, M, N> const & lhs,
                 MaRC::Matrix<T, M, N> const & rhs)
 {
     return !(lhs == rhs);
-}
-
-// ---------------------------------------------------------
-
-/**
- * @brief Stream insertion operator
- *
- * @relates MaRC::Matrix
- */
-template <typename T, std::size_t M, std::size_t N>
-std::ostream & operator<<(std::ostream & s,
-                          MaRC::Matrix<T, M, N> const & m)
-{
-    s << "(" << M << " x " << N << ")\n";
-
-    for (std::size_t row = 0; row < M; ++row) {
-        for (std::size_t col = 0; col < N; ++col) {
-            s << " " << m(row, col);
-        }
-
-        s << '\n';
-    }
-
-    return s;
 }
 
 

--- a/lib/marc/Vector.h
+++ b/lib/marc/Vector.h
@@ -4,7 +4,7 @@
  *
  * %MaRC mathematical vector class and operations.
  *
- * Copyright (C) 2004, 2017-2018  Ossama Othman
+ * Copyright (C) 2004, 2017-2018, 2021  Ossama Othman
  *
  * SPDX-License-Identifier: LGPL-2.1-or-later
  *
@@ -444,24 +444,6 @@ bool operator!=(MaRC::Vector<T, M> const & lhs,
                 MaRC::Vector<T, M> const & rhs)
 {
     return !(lhs == rhs);
-}
-
-// ---------------------------------------------------------
-
-/**
- * @brief Stream insertion operator.
- *
- * @relates MaRC::Vector
- */
-template <typename T, std::size_t M>
-std::ostream & operator<<(std::ostream & s, MaRC::Vector<T, M> const & v)
-{
-    s << "(" << M << ")\n";
-
-    for (std::size_t row = 0; row < M; ++row)
-        s << " " << v[row] << '\n';
-
-    return s;
 }
 
 

--- a/lib/marc/ViewingGeometry.cpp
+++ b/lib/marc/ViewingGeometry.cpp
@@ -17,10 +17,10 @@
 #include "Log.h"
 #include "config.h"  // For NDEBUG
 
-/**
- * @todo Should this be an equivalent %MaRC include directive?
- */
-#include <fmt/ostream.h>
+#ifndef NDEBUG
+# include "matrix_formatter.h"
+# include "vector_formatter.h"
+#endif  // NDEBUG
 
 #include <cmath>
 #include <limits>

--- a/lib/marc/matrix_formatter.h
+++ b/lib/marc/matrix_formatter.h
@@ -1,0 +1,73 @@
+// -*- C++ -*-
+/**
+ * @file matrix_formatter.h
+ *
+ * %MaRC matrix class formatting.
+ *
+ * Copyright (C) 2021  Ossama Othman
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ * @author Ossama Othman
+ */
+
+#ifndef MARC_MATRIX_FORMATTER_H
+#define MARC_MATRIX_FORMATTER_H
+
+#include "marc/Matrix.h"
+
+#include <fmt/format.h>
+
+
+/**
+ * @brief Formatter for @c MaRC::Matrix.
+ *
+ * This template specialization of @c fmt::formatter<> allows a
+ * @c MaRC::Matrix to be directly formatted in a fmtlib call.  For
+ * example:
+ * @code{.cpp}
+ *     MaRC::Matrix<double, 3. 3> m{ ... };
+ *     fmt::print("Matrix is: {}", m);
+ * @endcode
+ * will yield output such as:
+ * @code{.txt}
+ * Matrix is: (3 x 3)
+ * ⎡   -0.8896157352145879 -1.1758004881892886e-16   -0.4567098024551349 ⎤
+ * ⎢  -0.12770016341784404      0.9601139602111619   0.24874455103719437 ⎥
+ * ⎣    0.4384934571024569      0.2796089830596282   -0.8541324866030424 ⎦
+ * @endcode
+ */
+template <typename T, std::size_t M, std::size_t N>
+struct fmt::formatter<MaRC::Matrix<T, M, N>>
+    : formatter<T>
+{
+    template <typename FormatContext>
+    auto format(MaRC::Matrix<T, M, N> const & m,
+                FormatContext & ctx) -> decltype(ctx.out())
+    {
+        format_to(ctx.out(), "({} x {})\n", M, N);
+        format_to(ctx.out(), "⎡");
+
+        for (std::size_t row = 0; row < M; ++row) {
+            constexpr auto last_row = M - 1;
+
+            if (row == last_row)
+                format_to(ctx.out(), "⎣");
+            else if (row != 0 && row != last_row)
+                format_to(ctx.out(), "⎢");
+
+            for (std::size_t col = 0; col < N; ++col)
+                format_to(ctx.out(), " {:24}", m(row, col));
+
+            if (row == 0)
+                format_to(ctx.out(), " ⎤\n");
+            else if (row != last_row)
+                format_to(ctx.out(), " ⎥\n");
+        }
+
+        return format_to(ctx.out(), " ⎦\n");
+    }
+};
+
+
+#endif  /* MARC_MATRIX_FORMATTER_H */

--- a/lib/marc/vector_formatter.h
+++ b/lib/marc/vector_formatter.h
@@ -1,0 +1,72 @@
+// -*- C++ -*-
+/**
+ * @file vector_formatter.h
+ *
+ * %MaRC vector class and operations.
+ *
+ * Copyright (C) 2021  Ossama Othman
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ * @author Ossama Othman
+ */
+
+#ifndef MARC_VECTOR_FORMATTER_H
+#define MARC_VECTOR_FORMATTER_H
+
+#include "marc/Vector.h"
+
+#include <fmt/format.h>
+
+
+/**
+ * @brief Formatter for @c MaRC::Vector.
+ *
+ * This template specialization of @c fmt::formatter<> allows a
+ * @c MaRC::Vector to be directly formatted in a fmtlib call.  For
+ * example:
+ * @code{.cpp}
+ *     MaRC::Vector<double, 3> v{ ... };
+ *     fmt::print("Vector is: {}", v);
+ * @endcode
+ * will yield output such as:
+ * @code{.txt}
+ * Vector is: (3)
+ * ⎡       0.4384934571024569 ⎤
+ * ⎢       0.2796089830596282 ⎥
+ * ⎣      -0.8541324866030424 ⎦
+ * @endcode
+ */
+template <typename T, std::size_t M>
+struct fmt::formatter<MaRC::Vector<T, M>>
+    : formatter<T>
+{
+    template <typename FormatContext>
+    auto format(MaRC::Vector<T, M> const & v,
+                FormatContext & ctx) -> decltype(ctx.out())
+    {
+        format_to(ctx.out(), "({})\n", M);
+        format_to(ctx.out(), "⎡");
+
+        for (std::size_t row = 0; row < M; ++row) {
+            constexpr auto last_row = M - 1;
+
+            if (row == last_row)
+                format_to(ctx.out(), "⎣");
+            else if (row != 0 && row != last_row)
+                format_to(ctx.out(), "⎢");
+
+            format_to(ctx.out(), " {:24} ", v[row]);
+
+            if (row == 0)
+                format_to(ctx.out(), "⎤\n");
+            else if (row != last_row)
+                format_to(ctx.out(), "⎥\n");
+        }
+
+        return format_to(ctx.out(), "⎦\n");
+    }
+};
+
+
+#endif  /* MARC_VECTOR_FORMATTER_H */


### PR DESCRIPTION
Add template specializations of `fmt::formatter<>` that allow a` MaRC::Matrix` or MaRC::Vector to be directly formatted in a [fmtlib](https://fmt.dev/) call.

See [Formatting User-Defined Types](https://fmt.dev/dev/api.html#udt) in the fmtlib API documentation for additional information.