### PR TITLE
lib: Strategize MaRC image compositing code.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,6 +100,7 @@ tests/ViewingGeometry_Test
 tests/Mercator_Test
 tests/Orthographic_Test
 tests/PolarStereographic_Test
+tests/compositing_strategy_test
 tests/extrema_test
 tests/log_test
 tests/optional_test

--- a/lib/marc/InterpolationStrategy.h
+++ b/lib/marc/InterpolationStrategy.h
@@ -30,6 +30,7 @@ namespace MaRC
     {
     public:
 
+        /// Constructor.
         InterpolationStrategy() = default;
 
         // Disallow copying.

--- a/lib/marc/LatitudeImage.h
+++ b/lib/marc/LatitudeImage.h
@@ -85,7 +85,7 @@ namespace MaRC
         /// returned instead of planetocentric latitudes.
         bool const graphic_latitudes_;
 
-  };
+    };
 
 } // End MaRC namespace
 

--- a/lib/marc/Makefile.am
+++ b/lib/marc/Makefile.am
@@ -43,6 +43,10 @@ libMaRC_la_SOURCES = \
   BilinearInterpolation.cpp \
   NullInterpolation.cpp \
   \
+  first_read.cpp \
+  unweighted_average.cpp \
+  weighted_average.cpp \
+  \
   SourceImage.cpp \
   VirtualImage.cpp \
   MuImage.cpp \
@@ -97,12 +101,17 @@ nobase_pkginclude_HEADERS = \
   GLLGeometricCorrection.h \
   NullGeometricCorrection.h \
   \
+  PhotometricCorrection.h \
+  NullPhotometricCorrection.h \
+  \
   InterpolationStrategy.h \
   BilinearInterpolation.h \
   NullInterpolation.h \
   \
-  PhotometricCorrection.h \
-  NullPhotometricCorrection.h \
+  compositing_strategy.h \
+  first_read.h \
+  unweighted_average.h \
+  weighted_average.h \
   \
   Map_traits.h \
   MapFactory.h \

--- a/lib/marc/MosaicImage.cpp
+++ b/lib/marc/MosaicImage.cpp
@@ -1,7 +1,7 @@
 /**
  * @file MosaicImage.cpp
  *
- * Copyright (C) 2003-2004, 2017, 2020  Ossama Othman
+ * Copyright (C) 2003-2004, 2017, 2020-2021  Ossama Othman
  *
  * SPDX-License-Identifier: LGPL-2.1-or-later
  *
@@ -10,17 +10,153 @@
 
 #include "MosaicImage.h"
 #include "PhotoImage.h"
-#include "Mathematics.h"
 
+
+namespace
+{
+    bool
+    no_average(MaRC::MosaicImage::list_type const & images,
+               double lat,
+               double lon,
+               double & data)
+    {
+        // No averaging.  Just return the first found datum.
+        for (auto const & i : images)
+            if (i->read_data(lat, lon, data))
+                return true;
+
+        return false;
+    }
+
+    bool
+    unweighted_average(MaRC::MosaicImage::list_type const & images,
+                       double lat,
+                       double lon,
+                       double & data)
+    {
+        /**
+         * @todo We use a @c long @c double variable to store the data
+         *       sum to avoid a potential overflow during the
+         *       addition.  Alternatively, calculating the mean
+         *       iteratively could instead be used to avoid the
+         *       potential overflow like so:
+         * @code
+         * double average = 0;
+         * int count = 0;
+         * for (auto const & i : images) {
+         *     if (i->read_data(lat, lon, data)) {
+         *         average += (data - average) / count;
+         *         ++count;
+         *     }
+         * }
+         *
+         * data = average;
+         * @endcode
+         * @see http://www.heikohoffmann.de/htmlthesis/node134.html
+         */
+
+        // Sum of data from potentially multiple images at given
+        // latitude and longitude.
+        long double sum = 0;
+
+        // Datum count.
+        int count = 0;
+
+        for (auto const & i : images) {
+            if (i->read_data(lat, lon, data)) {
+                sum += data;
+                ++count;
+            }
+        }
+
+        if (count > 0) {
+            // Calculate the average.
+            data = static_cast<double>(sum / count);
+
+            return true;
+        }
+
+        return false;
+    }
+
+    bool
+    weighted_average(MaRC::MosaicImage::list_type const & images,
+                     double lat,
+                     double lon,
+                     double & data)
+    {
+        // Weighted sum of data from potentially multiple images at
+        // given latitude and longitude.
+        long double weighted_data_sum = 0;
+
+        // Sum of shortest distances.
+        unsigned long long weight_sum = 0;
+
+        for (auto const & i : images) {
+            // Shortest distance to an edge of the source image or a
+            // blank value in the source image.  This is used as a
+            // weight for the datum.
+            std::size_t weight = 1;
+
+            // Scan for data weight.
+            static constexpr bool scan = true;
+
+            /**
+             * @todo Move weight calculation code from @c PhotoImage
+             *       to @c MosaicImage.
+             */
+            if (i->read_data(lat,
+                             lon,
+                             data,
+                             weight,
+                             scan)) {
+                weighted_data_sum += weight * data;
+                weight_sum += weight;
+            }
+        }
+
+        // Perform the average.
+        if (weight_sum > 0)  {
+            data = static_cast<double>(weighted_data_sum / weight_sum);
+
+            return true;
+        }
+
+        return false;
+    }
+
+    MaRC::MosaicImage::avg_func_type
+    get_average_function(MaRC::MosaicImage::list_type const & images,
+                         MaRC::MosaicImage::average_type type)
+    {
+        if (images.size() < 2) {
+            /*
+              Note that we override and disable averaging if only one
+              image exists in the image set.  There is no point in
+              attempting averaging in that case.
+            */
+            return no_average;
+        }
+
+        switch (type) {
+        case MaRC::MosaicImage::AVG_NONE:
+        default:
+            return no_average;
+        case MaRC::MosaicImage::AVG_UNWEIGHTED:
+            return unweighted_average;
+        case MaRC::MosaicImage::AVG_WEIGHTED:
+            return weighted_average;
+        }
+    }
+}
+
+// ---------------------------------------------------------------------
 
 MaRC::MosaicImage::MosaicImage(list_type && images,
                                average_type type)
     : images_(std::move(images))
-    , average_type_(images_.size() < 2 ? AVG_NONE : type)
+    , average_(get_average_function(images_, type))
 {
-    // Note that we override and disable averaging if only one image
-    // exists in the image set.  There is no point in attempting
-    // averaging in that case.
 }
 
 bool
@@ -28,71 +164,5 @@ MaRC::MosaicImage::read_data(double lat,
                              double lon,
                              double & data) const
 {
-    bool found_data = false;
-
-    // Weighted sum of data from potentially multiple images at given
-    // latitude and longitude.
-    long double weighted_data_sum = 0;
-
-    // Sum of shortest distances.
-    unsigned long long weight_sum = 0;
-
-    for (auto const & i : this->images_) {
-        /**
-         * @todo Find a more elegant way to perform averaging than
-         *       this switch statement.
-         */
-        switch (this->average_type_) {
-        case AVG_WEIGHTED:  // Weighted averaging.
-            {
-                // Shortest distance to an edge of the source image or
-                // a blank value in the source image.  This is used as
-                // a weight when using weighted averaging.
-                std::size_t weight = 1;
-
-                // Scan for data weight.
-                static constexpr bool scan = true;
-
-                if (i->read_data(lat,
-                                 lon,
-                                 data,
-                                 weight,
-                                 scan)) {
-                    weighted_data_sum += weight * data;
-                    weight_sum += weight;
-
-                    found_data = true;
-                }
-            }
-
-            break;
-
-        case AVG_UNWEIGHTED:  // Unweighted averaging.
-            if (i->read_data(lat, lon, data)) {
-                weighted_data_sum += data;
-                ++weight_sum;
-
-                found_data = true;
-            }
-
-            break;
-
-        default:      // No averaging
-            if (i->read_data(lat, lon, data)) {
-                found_data = true;
-
-                // No point in continuing.  Just return the first
-                // found datum.
-                return found_data;
-            }
-
-          break;
-        }
-    }
-
-    // Perform the average.
-    if (weight_sum > 0)
-        data = static_cast<double>(weighted_data_sum / weight_sum);
-
-    return found_data;
+    return this->average_(this->images_, lat, lon, data);
 }

--- a/lib/marc/MosaicImage.cpp
+++ b/lib/marc/MosaicImage.cpp
@@ -12,150 +12,11 @@
 #include "PhotoImage.h"
 
 
-namespace
-{
-    bool
-    no_average(MaRC::MosaicImage::list_type const & images,
-               double lat,
-               double lon,
-               double & data)
-    {
-        // No averaging.  Just return the first found datum.
-        for (auto const & i : images)
-            if (i->read_data(lat, lon, data))
-                return true;
-
-        return false;
-    }
-
-    bool
-    unweighted_average(MaRC::MosaicImage::list_type const & images,
-                       double lat,
-                       double lon,
-                       double & data)
-    {
-        /**
-         * @todo We use a @c long @c double variable to store the data
-         *       sum to avoid a potential overflow during the
-         *       addition.  Alternatively, calculating the mean
-         *       iteratively could instead be used to avoid the
-         *       potential overflow like so:
-         * @code
-         * double average = 0;
-         * int count = 0;
-         * for (auto const & i : images) {
-         *     if (i->read_data(lat, lon, data)) {
-         *         average += (data - average) / count;
-         *         ++count;
-         *     }
-         * }
-         *
-         * data = average;
-         * @endcode
-         * @see http://www.heikohoffmann.de/htmlthesis/node134.html
-         */
-
-        // Sum of data from potentially multiple images at given
-        // latitude and longitude.
-        long double sum = 0;
-
-        // Datum count.
-        int count = 0;
-
-        for (auto const & i : images) {
-            if (i->read_data(lat, lon, data)) {
-                sum += data;
-                ++count;
-            }
-        }
-
-        if (count > 0) {
-            // Calculate the average.
-            data = static_cast<double>(sum / count);
-
-            return true;
-        }
-
-        return false;
-    }
-
-    bool
-    weighted_average(MaRC::MosaicImage::list_type const & images,
-                     double lat,
-                     double lon,
-                     double & data)
-    {
-        // Weighted sum of data from potentially multiple images at
-        // given latitude and longitude.
-        long double weighted_data_sum = 0;
-
-        // Sum of shortest distances.
-        unsigned long long weight_sum = 0;
-
-        for (auto const & i : images) {
-            // Shortest distance to an edge of the source image or a
-            // blank value in the source image.  This is used as a
-            // weight for the datum.
-            std::size_t weight = 1;
-
-            // Scan for data weight.
-            static constexpr bool scan = true;
-
-            /**
-             * @todo Move weight calculation code from @c PhotoImage
-             *       to @c MosaicImage.
-             */
-            if (i->read_data(lat,
-                             lon,
-                             data,
-                             weight,
-                             scan)) {
-                weighted_data_sum += weight * data;
-                weight_sum += weight;
-            }
-        }
-
-        // Perform the average.
-        if (weight_sum > 0)  {
-            data = static_cast<double>(weighted_data_sum / weight_sum);
-
-            return true;
-        }
-
-        return false;
-    }
-
-    MaRC::MosaicImage::avg_func_type
-    get_average_function(MaRC::MosaicImage::list_type const & images,
-                         MaRC::MosaicImage::average_type type)
-    {
-        if (images.size() < 2) {
-            /*
-              Note that we override and disable averaging if only one
-              image exists in the image set.  There is no point in
-              attempting averaging in that case.
-            */
-            return no_average;
-        }
-
-        switch (type) {
-        case MaRC::MosaicImage::AVG_NONE:
-        default:
-            return no_average;
-        case MaRC::MosaicImage::AVG_UNWEIGHTED:
-            return unweighted_average;
-        case MaRC::MosaicImage::AVG_WEIGHTED:
-            return weighted_average;
-        }
-    }
-}
-
-// ---------------------------------------------------------------------
-
-MaRC::MosaicImage::MosaicImage(list_type && images,
-                               average_type type)
+MaRC::MosaicImage::MosaicImage(
+    list_type && images,
+    std::unique_ptr<compositing_strategy> compositor)
     : images_(std::move(images))
-    , average_(get_average_function(images_, type))
+    , compositor_(std::move(compositor))
 {
 }
 
@@ -164,5 +25,5 @@ MaRC::MosaicImage::read_data(double lat,
                              double lon,
                              double & data) const
 {
-    return this->average_(this->images_, lat, lon, data);
+    return this->compositor_->composite(this->images_, lat, lon, data);
 }

--- a/lib/marc/MosaicImage.cpp
+++ b/lib/marc/MosaicImage.cpp
@@ -25,5 +25,6 @@ MaRC::MosaicImage::read_data(double lat,
                              double lon,
                              double & data) const
 {
-    return this->compositor_->composite(this->images_, lat, lon, data);
+    return
+        this->compositor_->composite(this->images_, lat, lon, data) > 0;
 }

--- a/lib/marc/MosaicImage.h
+++ b/lib/marc/MosaicImage.h
@@ -55,13 +55,14 @@ namespace MaRC
         /// Destructor.
         ~MosaicImage() override = default;
 
-        /// Retrieve physical data from mosaic images.
         /**
+         * @brief Retrieve physical data from mosaic images.
+         *
          * Retrieve physical data from all mosaic images that have
          * data at the given latitude and longitude.  The configured
-         * data averaging strategy will be applied in cases where
-         * multiple images have data at the given longitude and
-         * latitude.
+         * data compositing strategy will be applied in cases where
+         * multiple images have data at the specified latitude and
+         * longitude.
          *
          * @param[in]  lat  Planetocentric latitude in radians.
          * @param[in]  lon  Longitude in radians.

--- a/lib/marc/MosaicImage.h
+++ b/lib/marc/MosaicImage.h
@@ -14,9 +14,7 @@
 
 #include <marc/SourceImage.h>
 #include <marc/Export.h>
-
-#include <memory>
-#include <vector>
+#include <marc/compositing_strategy.h>
 
 
 namespace MaRC
@@ -37,31 +35,16 @@ namespace MaRC
          * Type of list containing source images that comprise the
          * mosaic.
          */
-        using list_type = std::vector<std::unique_ptr<SourceImage>>;
-
-        /**
-         * @enum average_type
-         *
-         * The type of averaging to be performed on physical data
-         * retrieved from multiple images that contain data at the
-         * given latitude and longitude.
-         */
-        enum average_type { AVG_NONE, AVG_UNWEIGHTED, AVG_WEIGHTED };
-
-        typedef bool (*avg_func_type)(list_type const & images,
-                                      double lat,
-                                      double lon,
-                                      double & data);
+        using list_type = MaRC::compositing_strategy::list_type;
 
         /// Constructor.
         /**
-         * @param[in,out] images The list of images to be mosaiced.
-         *                       Ownership of the list is transferred
-         *                       to the @c MosaicImage by peforming a
-         *                       C++11 move.
-         * @param[in]     type   The type of averaging to be performed.
+         * @param[in,out] images     The list of images to be
+         *                           mosaiced.
+         * @param[in,out] compositor Data compositing strategy.
          */
-        MosaicImage(list_type && images, average_type type);
+        MosaicImage(list_type && images,
+                    std::unique_ptr<compositing_strategy> compositor);
 
         // Disallow copying and moving.
         MosaicImage(MosaicImage const &) = delete;
@@ -98,20 +81,8 @@ namespace MaRC
         /// Set of images
         list_type const images_;
 
-        /**
-         * @brief Data averaging strategy.
-         *
-         * This function performs an average on data retrieved from
-         * multiple images.  The type of average (e.g. none,
-         * unweighted, or weighted) corresponds to the one specified
-         * by the user when instantiating this class.
-         *
-         * @todo Currently this is a simple pointer to function.
-         *       An alternative approach would be to implement a class
-         *       hiearchy, similar to what is done for interpolation
-         *       in MaRC (see @c MaRC::InterpolationStrategy).
-         */
-        avg_func_type const average_;
+        /// Data compositing strategy.
+        std::unique_ptr<compositing_strategy const> const compositor_;
 
     };
 

--- a/lib/marc/MosaicImage.h
+++ b/lib/marc/MosaicImage.h
@@ -2,7 +2,7 @@
 /**
  * @file MosaicImage.h
  *
- * Copyright (C) 2003-2004, 2017-2018  Ossama Othman
+ * Copyright (C) 2003-2004, 2017-2018, 2021  Ossama Othman
  *
  * SPDX-License-Identifier: LGPL-2.1-or-later
  *
@@ -47,6 +47,11 @@ namespace MaRC
          * given latitude and longitude.
          */
         enum average_type { AVG_NONE, AVG_UNWEIGHTED, AVG_WEIGHTED };
+
+        typedef bool (*avg_func_type)(list_type const & images,
+                                      double lat,
+                                      double lon,
+                                      double & data);
 
         /// Constructor.
         /**
@@ -93,9 +98,20 @@ namespace MaRC
         /// Set of images
         list_type const images_;
 
-        /// The type of averaging to perform on data retrieved from
-        /// multiple images.
-        average_type const average_type_;
+        /**
+         * @brief Data averaging strategy.
+         *
+         * This function performs an average on data retrieved from
+         * multiple images.  The type of average (e.g. none,
+         * unweighted, or weighted) corresponds to the one specified
+         * by the user when instantiating this class.
+         *
+         * @todo Currently this is a simple pointer to function.
+         *       An alternative approach would be to implement a class
+         *       hiearchy, similar to what is done for interpolation
+         *       in MaRC (see @c MaRC::InterpolationStrategy).
+         */
+        avg_func_type const average_;
 
     };
 

--- a/lib/marc/PhotoImage.cpp
+++ b/lib/marc/PhotoImage.cpp
@@ -97,7 +97,7 @@ MaRC::PhotoImage::PhotoImage(std::vector<double> && image,
 bool
 MaRC::PhotoImage::read_data(double lat, double lon, double & data) const
 {
-    std::size_t weight = 1;  // Unused.
+    double weight = 1;  // Unused.
 
     static constexpr bool scan = false; // Do not scan for data weight.
 
@@ -108,7 +108,7 @@ bool
 MaRC::PhotoImage::read_data(double lat,
                             double lon,
                             double & data,
-                            std::size_t & weight,
+                            double & weight,
                             bool scan) const
 {
     /**
@@ -173,7 +173,7 @@ void
 MaRC::PhotoImage::scan_samples(std::size_t line,
                                std::size_t left,
                                std::size_t right,
-                               std::size_t & weight) const
+                               double & weight) const
 {
     // Scan across samples on given line.
 
@@ -202,7 +202,7 @@ void
 MaRC::PhotoImage::scan_lines(std::size_t i,
                              std::size_t top,
                              std::size_t bottom,
-                             std::size_t & weight) const
+                             double & weight) const
 {
     // Search the half-open interval [top, bottom).
     auto body_iter =
@@ -217,13 +217,17 @@ MaRC::PhotoImage::scan_lines(std::size_t i,
                                                  // line in mask.
 
     if (line != last)
-        weight = std::min(line - first, weight);
+        weight =
+            std::min(
+                static_cast<
+                std::remove_reference<decltype(weight)>::type>(line - first),
+                weight);
 }
 
 void
 MaRC::PhotoImage::data_weight(std::size_t i,
                               std::size_t k,
-                              std::size_t & weight) const
+                              double & weight) const
 {
     /**
      * @note This method assumes at "i" is in the range

--- a/lib/marc/PhotoImage.cpp
+++ b/lib/marc/PhotoImage.cpp
@@ -1,7 +1,7 @@
 /**
  * @file PhotoImage.cpp
  *
- * Copyright (C) 1998-1999, 2003-2005, 2017, 2019  Ossama Othman
+ * Copyright (C) 1998-1999, 2003-2005, 2017, 2019, 2021  Ossama Othman
  *
  * SPDX-License-Identifier: LGPL-2.1-or-later
  *
@@ -28,10 +28,10 @@
 namespace
 {
     /// Create body mask vector for use in "sky removal".
-    auto body_mask(std::size_t samples,
-                   std::size_t lines,
-                   MaRC::PhotoImageParameters const * config,
-                   MaRC::ViewingGeometry const * geometry)
+    auto make_body_mask(std::size_t samples,
+                        std::size_t lines,
+                        MaRC::PhotoImageParameters const * config,
+                        MaRC::ViewingGeometry const * geometry)
     {
         if (!config || !geometry) {
             throw std::invalid_argument(
@@ -61,10 +61,10 @@ MaRC::PhotoImage::PhotoImage(std::vector<double> && image,
     , bottom_   (lines - config->nibble_bottom())
     , config_   (std::move(config))
     , geometry_ (std::move(geometry))
-    , body_mask_(body_mask(samples,
-                           lines,
-                           config_.get(),
-                           geometry_.get()))
+    , body_mask_(make_body_mask(samples,
+                                lines,
+                                config_.get(),
+                                geometry_.get()))
 {
     if (samples < 2 || lines < 2) {
         // Why would there ever be a one pixel source image?

--- a/lib/marc/PhotoImage.h
+++ b/lib/marc/PhotoImage.h
@@ -105,7 +105,7 @@ namespace MaRC
         bool read_data(double lat,
                        double lon,
                        double & data,
-                       std::size_t & weight,
+                       double & weight,
                        bool scan = true) const override;
 
         /// Left side of image.
@@ -143,7 +143,7 @@ namespace MaRC
         void scan_samples(std::size_t line,
                           std::size_t left,
                           std::size_t right,
-                          std::size_t & weight) const;
+                          double & weight) const;
 
         /**
          * @brief Scan across lines for the data weight.
@@ -160,7 +160,7 @@ namespace MaRC
         void scan_lines(std::size_t sample,
                         std::size_t top,
                         std::size_t bottom,
-                        std::size_t & weight) const;
+                        double & weight) const;
 
         /**
          * @brief Obtain data weight for given image pixel.
@@ -177,7 +177,7 @@ namespace MaRC
          */
         void data_weight(std::size_t i,
                          std::size_t k,
-                         std::size_t & weight) const;
+                         double & weight) const;
 
     private:
 

--- a/lib/marc/PhotoImage.h
+++ b/lib/marc/PhotoImage.h
@@ -2,7 +2,7 @@
 /**
  * @file PhotoImage.h
  *
- * Copyright (C) 1999, 2003-2005, 2017-2018  Ossama Othman
+ * Copyright (C) 1999, 2003-2005, 2017-2018, 2021  Ossama Othman
  *
  * SPDX-License-Identifier: LGPL-2.1-or-later
  *
@@ -37,6 +37,8 @@ namespace MaRC
     class MARC_API PhotoImage final : public SourceImage
     {
     public:
+
+        using body_mask_type = std::vector<bool>;
 
         /// Constructor
         /**
@@ -105,6 +107,24 @@ namespace MaRC
                        double & data,
                        std::size_t & weight,
                        bool scan = true) const override;
+
+        /// Left side of image.
+        std::size_t left() const { return this->left_; }
+
+        /// Right side of image.
+        std::size_t right() const { return this->right_; }
+
+        /// Top side of image.
+        std::size_t top() const { return this->top_; }
+
+        /// Bottom side of image.
+        std::size_t bottom() const { return this->bottom_; }
+
+        /// Mask used when "removing" sky from source image.
+        body_mask_type const & body_mask() const
+        {
+            return this->body_mask_;
+        }
 
     private:
 
@@ -199,7 +219,7 @@ namespace MaRC
          *
          * @see MosaicImage
          */
-        std::vector<bool> body_mask_;
+        body_mask_type body_mask_;
 
     };
 

--- a/lib/marc/SourceImage.cpp
+++ b/lib/marc/SourceImage.cpp
@@ -1,7 +1,7 @@
 /**
  * @file SourceImage.cpp
  *
- * Copyright (C) 1999, 2003-2004, 2017  Ossama Othman
+ * Copyright (C) 1999, 2003-2004, 2017, 2021  Ossama Othman
  *
  * SPDX-License-Identifier: LGPL-2.1-or-later
  *
@@ -15,7 +15,7 @@ bool
 MaRC::SourceImage::read_data(double lat,
                              double lon,
                              double & data,
-                             std::size_t & /* weight */,
+                             double & /* weight */,
                              bool /* scan */) const
 {
     return this->read_data(lat, lon, data);

--- a/lib/marc/SourceImage.h
+++ b/lib/marc/SourceImage.h
@@ -2,7 +2,7 @@
 /**
  * @file SourceImage.h
  *
- * Copyright (C) 1999, 2003-2004, 2017-2018  Ossama Othman
+ * Copyright (C) 1999, 2003-2004, 2017-2018, 2021  Ossama Othman
  *
  * SPDX-License-Identifier: LGPL-2.1-or-later
  *
@@ -60,8 +60,9 @@ namespace MaRC
                                double lon,
                                double & data) const = 0;
 
-        /// Retrieve data and weight from source image.
         /**
+         * @brief Retrieve data and weight from source image.
+         *
          * Retrieve physical data and weight from source image.  The
          * default implementation merely ignores the @a weight and
          * @a scan arguments, and forwards the call to the concrete
@@ -72,8 +73,7 @@ namespace MaRC
          * @param[in]     lat    Planetocentric latitude in radians.
          * @param[in]     lon    Longitude in radians.
          * @param[out]    data   Physical data retrieved from image.
-         * @param[in,out] weight Distance from pixel to closest edge
-         *                       or blank pixel.
+         * @param[in,out] weight Physical data weight.
          * @param[in]     scan   Flag that determines if a data weight
          *                       scan is performed..
          *
@@ -83,7 +83,7 @@ namespace MaRC
         virtual bool read_data(double lat,
                                double lon,
                                double & data,
-                               std::size_t & weight,
+                               double & weight,
                                bool scan) const;
 
     };

--- a/lib/marc/compositing_strategy.h
+++ b/lib/marc/compositing_strategy.h
@@ -61,12 +61,12 @@ namespace MaRC
          * @param[in]  lon    Longitude in radians.
          * @param[out] datum  Composited datum.
          *
-         * @return @c true if compositing succeeded.
+         * @return The number of images that were composited.
          */
-        virtual bool composite(list_type const & images,
-                               double lat,
-                               double lon,
-                               double & data) const = 0;
+        virtual int composite(list_type const & images,
+                              double lat,
+                              double lon,
+                              double & data) const = 0;
 
     };
 

--- a/lib/marc/compositing_strategy.h
+++ b/lib/marc/compositing_strategy.h
@@ -1,0 +1,75 @@
+// -*- C++ -*-
+/**
+ * @file compositing_strategy.h
+ *
+ * Copyright (C) 2021  Ossama Othman
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ * @author Ossama Othman
+ */
+
+#ifndef MARC_COMPOSITING_STRATEGY_H
+#define MARC_COMPOSITING_STRATEGY_H
+
+#include <marc/SourceImage.h>
+#include <marc/Export.h>
+
+#include <memory>
+#include <vector>
+
+namespace MaRC
+{
+
+    /**
+     * @class compositing_strategy compositing_strategy.h <marc/compositing_strategy.h>
+     *
+     * @brief Abstract base class for all compositing strategies.
+     *
+     * Concrete compositing classes must implement the interface
+     * required by this abstract base class.
+     */
+    class MARC_API compositing_strategy
+    {
+    public:
+
+        /// Type of list containing source images to be composited.
+        using list_type = std::vector<std::unique_ptr<SourceImage>>;
+
+        /// Constructor.
+        compositing_strategy() = default;
+
+        // Disallow copying.
+        compositing_strategy(compositing_strategy const &) = delete;
+        compositing_strategy & operator=(
+            compositing_strategy const &) = delete;
+
+        // Disallow moving.
+        compositing_strategy(compositing_strategy &&) = delete;
+        compositing_strategy & operator=(
+            compositing_strategy &&) = delete;
+
+        /// Destructor.
+        virtual ~compositing_strategy() = default;
+
+        /**
+         * @brief Perform compositing on data at given latitude and
+         *        longitude.         *
+
+         * @param[in]  images Set of images to composite.
+         * @param[in]  lat    Planetocentric latitude in radians.
+         * @param[in]  lon    Longitude in radians.
+         * @param[out] datum  Composited datum.
+         *
+         * @return @c true if compositing succeeded.
+         */
+        virtual bool composite(list_type const & images,
+                               double lat,
+                               double lon,
+                               double & data) const = 0;
+
+    };
+
+}
+
+#endif  /* MARC_COMPOSITING_STRATEGY_H */

--- a/lib/marc/first_read.cpp
+++ b/lib/marc/first_read.cpp
@@ -1,0 +1,26 @@
+/**
+ * @file first_read.cpp
+ *
+ * Copyright (C) 2003-2004, 2017, 2020-2021  Ossama Othman
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ * @author Ossama Othman
+ */
+
+#include "first_read.h"
+
+
+bool
+MaRC::first_read::composite(list_type const & images,
+                            double lat,
+                            double lon,
+                            double & data) const
+{
+    // Return the first found datum.
+    for (auto const & i : images)
+        if (i->read_data(lat, lon, data))
+            return true;
+
+    return false;
+}

--- a/lib/marc/first_read.cpp
+++ b/lib/marc/first_read.cpp
@@ -11,7 +11,7 @@
 #include "first_read.h"
 
 
-bool
+int
 MaRC::first_read::composite(list_type const & images,
                             double lat,
                             double lon,
@@ -20,7 +20,7 @@ MaRC::first_read::composite(list_type const & images,
     // Return the first found datum.
     for (auto const & i : images)
         if (i->read_data(lat, lon, data))
-            return true;
+            return 1;
 
-    return false;
+    return 0;
 }

--- a/lib/marc/first_read.h
+++ b/lib/marc/first_read.h
@@ -1,0 +1,52 @@
+// -*- C++ -*-
+/**
+ * @file first_read.h
+ *
+ * Copyright (C) 2021  Ossama Othman
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ * @author Ossama Othman
+ */
+
+#ifndef MARC_FIRST_READ_H
+#define MARC_FIRST_READ_H
+
+#include "marc/compositing_strategy.h"
+#include "marc/Export.h"
+
+
+namespace MaRC
+{
+
+    /**
+     * @class first_read first_read.h <marc/first_read.h>
+     *
+     * @brief First read datum compositing strategy.
+     *
+     * Compositing strategy that simply returns the first read datum
+     * from the image set.
+     */
+    class MARC_API first_read final : public compositing_strategy
+    {
+    public:
+
+        /// Destructor.
+        ~first_read() override = default;
+
+        /**
+         * @brief Return first read datum at given latitude and longitude.
+         *
+         * @see @c compositing_strategy for parameter details.
+         */
+        bool composite(list_type const & images,
+                       double lat,
+                       double lon,
+                       double & data) const override;
+
+    };
+
+}
+
+
+#endif  /* MARC_FIRST_READ_H */

--- a/lib/marc/first_read.h
+++ b/lib/marc/first_read.h
@@ -39,10 +39,10 @@ namespace MaRC
          *
          * @see @c compositing_strategy for parameter details.
          */
-        bool composite(list_type const & images,
-                       double lat,
-                       double lon,
-                       double & data) const override;
+        int composite(list_type const & images,
+                      double lat,
+                      double lon,
+                      double & data) const override;
 
     };
 

--- a/lib/marc/unweighted_average.cpp
+++ b/lib/marc/unweighted_average.cpp
@@ -11,7 +11,7 @@
 #include "unweighted_average.h"
 
 
-bool
+int
 MaRC::unweighted_average::composite(list_type const & images,
                                     double lat,
                                     double lon,
@@ -54,9 +54,7 @@ MaRC::unweighted_average::composite(list_type const & images,
     if (count > 0) {
         // Calculate the average.
         data = static_cast<double>(sum / count);
-
-        return true;
     }
 
-    return false;
+    return count;
 }

--- a/lib/marc/unweighted_average.cpp
+++ b/lib/marc/unweighted_average.cpp
@@ -1,0 +1,62 @@
+/**
+ * @file unweighted_average.cpp
+ *
+ * Copyright (C) 2003-2004, 2017, 2020-2021  Ossama Othman
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ * @author Ossama Othman
+ */
+
+#include "unweighted_average.h"
+
+
+bool
+MaRC::unweighted_average::composite(list_type const & images,
+                                    double lat,
+                                    double lon,
+                                    double & data) const
+{
+    /**
+     * @todo We use a @c long @c double variable to store the data sum
+     *       to avoid a potential overflow during the addition.
+     *       Alternatively, calculating the mean iteratively could
+     *       instead be used to avoid the potential overflow like so:
+     * @code
+     * double average = 0;
+     * int count = 0;
+     * for (auto const & i : images) {
+     *     if (i->read_data(lat, lon, data)) {
+     *         average += (data - average) / count;
+     *         ++count;
+     *     }
+     * }
+     *
+     * data = average;
+     * @endcode
+     * @see http://www.heikohoffmann.de/htmlthesis/node134.html
+     */
+
+    // Sum of data from potentially multiple images at given
+    // latitude and longitude.
+    long double sum = 0;
+
+    // Datum count.
+    int count = 0;
+
+    for (auto const & i : images) {
+        if (i->read_data(lat, lon, data)) {
+            sum += data;
+            ++count;
+        }
+    }
+
+    if (count > 0) {
+        // Calculate the average.
+        data = static_cast<double>(sum / count);
+
+        return true;
+    }
+
+    return false;
+}

--- a/lib/marc/unweighted_average.h
+++ b/lib/marc/unweighted_average.h
@@ -1,0 +1,51 @@
+// -*- C++ -*-
+/**
+ * @file unweighted_average.h
+ *
+ * Copyright (C) 2021  Ossama Othman
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ * @author Ossama Othman
+ */
+
+#ifndef MARC_UNWEIGHTED_AVERAGE_H
+#define MARC_UNWEIGHTED_AVERAGE_H
+
+#include "marc/compositing_strategy.h"
+#include "marc/Export.h"
+
+
+namespace MaRC
+{
+
+    /**
+     * @class unweighted_average unweighted_average.h <marc/unweighted_average.h>
+     *
+     * @brief Unweighted average compositing strategy.
+     *
+     * Composite data through an unweighted average.
+     */
+    class MARC_API unweighted_average final : public compositing_strategy
+    {
+    public:
+
+        /// Destructor.
+        ~unweighted_average() override = default;
+
+        /**
+         * @brief Average data at given latitude and longitude.
+         *
+         * @see @c compositing_strategy for parameter details.
+         */
+        bool composite(list_type const & images,
+                       double lat,
+                       double lon,
+                       double & data) const override;
+
+    };
+
+}
+
+
+#endif  /* MARC_UNWEIGHTED_AVERAGE_H */

--- a/lib/marc/unweighted_average.h
+++ b/lib/marc/unweighted_average.h
@@ -38,7 +38,7 @@ namespace MaRC
          *
          * @see @c compositing_strategy for parameter details.
          */
-        bool composite(list_type const & images,
+        int composite(list_type const & images,
                        double lat,
                        double lon,
                        double & data) const override;

--- a/lib/marc/weighted_average.cpp
+++ b/lib/marc/weighted_average.cpp
@@ -44,7 +44,7 @@ MaRC::weighted_average::composite(list_type const & images,
       Perform the weighted average only if more than one image
       contributed to avoid introducing floating point error, such as
       a datum of 200 for one image vs. 199.999999999996 obtained from
-      the weighted average calculation
+      the weighted average calculation.
     */
     if (count > 1 && weight_sum > 0)
         data = static_cast<double>(weighted_data_sum / weight_sum);

--- a/lib/marc/weighted_average.cpp
+++ b/lib/marc/weighted_average.cpp
@@ -1,0 +1,56 @@
+/**
+ * @file weighted_average.cpp
+ *
+ * Copyright (C) 2003-2004, 2017, 2020-2021  Ossama Othman
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ * @author Ossama Othman
+ */
+
+#include "weighted_average.h"
+
+
+bool
+MaRC::weighted_average::composite(list_type const & images,
+                                  double lat,
+                                  double lon,
+                                  double & data) const
+{
+    // Weighted sum of data from potentially multiple images at
+    // given latitude and longitude.
+    long double weighted_data_sum = 0;
+
+    // Sum of shortest distances.
+    unsigned long long weight_sum = 0;
+
+    for (auto const & i : images) {
+        /*
+          Shortest distance to an edge of the source image or a blank
+          value in the source image.  This is used as a weight for the
+          datum.
+        */
+        std::size_t weight = 1;
+
+        // Scan for data weight.
+        static constexpr bool scan = true;
+
+        /**
+         * @todo Move weight calculation code from @c PhotoImage
+         *       to @c MosaicImage.
+         */
+        if (i->read_data(lat, lon, data, weight, scan)) {
+            weighted_data_sum += weight * data;
+            weight_sum += weight;
+        }
+    }
+
+    // Perform the average.
+    if (weight_sum > 0)  {
+        data = static_cast<double>(weighted_data_sum / weight_sum);
+
+        return true;
+    }
+
+    return false;
+}

--- a/lib/marc/weighted_average.cpp
+++ b/lib/marc/weighted_average.cpp
@@ -40,9 +40,13 @@ MaRC::weighted_average::composite(list_type const & images,
         }
     }
 
-    // Perform the weighted average if more than one image
-    // contributed.
-    if (weight_sum > 0)
+    /*
+      Perform the weighted average only if more than one image
+      contributed to avoid introducing floating point error, such as
+      a datum of 200 for one image vs. 199.999999999996 obtained from
+      the weighted average calculation
+    */
+    if (count > 1 && weight_sum > 0)
         data = static_cast<double>(weighted_data_sum / weight_sum);
 
     return count;

--- a/lib/marc/weighted_average.cpp
+++ b/lib/marc/weighted_average.cpp
@@ -11,7 +11,7 @@
 #include "weighted_average.h"
 
 
-bool
+int
 MaRC::weighted_average::composite(list_type const & images,
                                   double lat,
                                   double lon,
@@ -23,6 +23,9 @@ MaRC::weighted_average::composite(list_type const & images,
 
     long double weight_sum = 0;
 
+    // Datum count.
+    int count = 0;
+
     for (auto const & i : images) {
         // Physical data weight.
         double weight = 1;
@@ -30,23 +33,17 @@ MaRC::weighted_average::composite(list_type const & images,
         // Scan for data weight.
         static constexpr bool scan = true;
 
-        /**
-         * @todo Move weight calculation code from @c PhotoImage
-         *       to @c MosaicImage.
-         */
         if (i->read_data(lat, lon, data, weight, scan)) {
             weighted_data_sum += weight * data;
             weight_sum += weight;
+            ++count;
         }
     }
 
     // Perform the weighted average if more than one image
     // contributed.
-    if (weight_sum > 0) {
+    if (weight_sum > 0)
         data = static_cast<double>(weighted_data_sum / weight_sum);
 
-        return true;
-    }
-
-    return false;
+    return count;
 }

--- a/lib/marc/weighted_average.cpp
+++ b/lib/marc/weighted_average.cpp
@@ -21,16 +21,11 @@ MaRC::weighted_average::composite(list_type const & images,
     // given latitude and longitude.
     long double weighted_data_sum = 0;
 
-    // Sum of shortest distances.
-    unsigned long long weight_sum = 0;
+    long double weight_sum = 0;
 
     for (auto const & i : images) {
-        /*
-          Shortest distance to an edge of the source image or a blank
-          value in the source image.  This is used as a weight for the
-          datum.
-        */
-        std::size_t weight = 1;
+        // Physical data weight.
+        double weight = 1;
 
         // Scan for data weight.
         static constexpr bool scan = true;
@@ -45,8 +40,9 @@ MaRC::weighted_average::composite(list_type const & images,
         }
     }
 
-    // Perform the average.
-    if (weight_sum > 0)  {
+    // Perform the weighted average if more than one image
+    // contributed.
+    if (weight_sum > 0) {
         data = static_cast<double>(weighted_data_sum / weight_sum);
 
         return true;

--- a/lib/marc/weighted_average.h
+++ b/lib/marc/weighted_average.h
@@ -1,0 +1,51 @@
+// -*- C++ -*-
+/**
+ * @file weighted_average.h
+ *
+ * Copyright (C) 2021  Ossama Othman
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ * @author Ossama Othman
+ */
+
+#ifndef MARC_WEIGHTED_AVERAGE_H
+#define MARC_WEIGHTED_AVERAGE_H
+
+#include "marc/compositing_strategy.h"
+#include "marc/Export.h"
+
+
+namespace MaRC
+{
+
+    /**
+     * @class weighted_average weighted_average.h <marc/weighted_average.h>
+     *
+     * @brief Weighted average compositing strategy.
+     *
+     * Composite data through a weighted average.
+     */
+    class MARC_API weighted_average final : public compositing_strategy
+    {
+    public:
+
+        /// Destructor.
+        ~weighted_average() override = default;
+
+        /**
+         * @brief Average data at given latitude and longitude.
+         *
+         * @see @c compositing_strategy for parameter details.
+         */
+        bool composite(list_type const & images,
+                       double lat,
+                       double lon,
+                       double & data) const override;
+
+    };
+
+}
+
+
+#endif  /* MARC_WEIGHTED_AVERAGE_H */

--- a/lib/marc/weighted_average.h
+++ b/lib/marc/weighted_average.h
@@ -38,10 +38,10 @@ namespace MaRC
          *
          * @see @c compositing_strategy for parameter details.
          */
-        bool composite(list_type const & images,
-                       double lat,
-                       double lon,
-                       double & data) const override;
+        int composite(list_type const & images,
+                      double lat,
+                      double lon,
+                      double & data) const override;
 
     };
 

--- a/src/MosaicImageFactory.h
+++ b/src/MosaicImageFactory.h
@@ -25,15 +25,15 @@ namespace MaRC
     /**
      * @class MosaicImageFactory
      *
-     * @brief Factory class that create MosaicImage objects.
+     * @brief Factory class that creates @c MosaicImage objects.
      *
-     * This class creates MosaicImage objects.  It is designed to
+     * This class creates @c MosaicImage objects.  It is designed to
      * decouple %FITS (for example) file and image operations from the
      * MosaicImage class.  It also exists to decouple the %MaRC parser
-     * grammar from the MosaicImage class.  This allows MosaicImage
-     * object creation to be delayed until it is time for the data in
-     * the MosaicImage to be mapped, which reduces run-time memory
-     * requirements.
+     * grammar from the @c MosaicImage class.  This allows
+     * @c MosaicImage object creation to be delayed until it is time
+     * for the data in the @c MosaicImage to be mapped, which reduces
+     * run-time memory requirements.
      */
     class MosaicImageFactory final : public SourceImageFactory
     {

--- a/src/MosaicImageFactory.h
+++ b/src/MosaicImageFactory.h
@@ -45,9 +45,18 @@ namespace MaRC
          */
         using list_type = std::list<std::unique_ptr<PhotoImageFactory>>;
 
+        /**
+         * @enum average_type
+         *
+         * The type of averaging to be performed on physical data
+         * retrieved from multiple images that contain data at a
+         * given latitude and longitude.
+         *
+         */
+        enum average_type { AVG_NONE, AVG_UNWEIGHTED, AVG_WEIGHTED };
+
         /// Constructor.
-        MosaicImageFactory(list_type && factories,
-                           MosaicImage::average_type type);
+        MosaicImageFactory(list_type && factories, average_type type);
 
         /// Destructor.
         ~MosaicImageFactory() override = default;
@@ -65,9 +74,15 @@ namespace MaRC
         /// List of PhotoImageFactory objects.
         list_type factories_;
 
-        /// The type of averaging to be performed when multiple images
-        /// overlap.
-        MosaicImage::average_type const average_type_;
+        /**
+         * @brief The type of averaging to be performed when multiple
+         *        images overlap.
+         *
+         * @todo Rather than "average type" use "compositor type"
+         *       since not all mosaic compositing strategies perform
+         *       averaging on image data.
+         */
+        average_type const average_type_;
 
   };
 

--- a/src/parse.yy
+++ b/src/parse.yy
@@ -333,7 +333,7 @@ double lon_interval;
 
 std::unique_ptr<MaRC::PhotoImageFactory> photo_factory;
 MaRC::MosaicImageFactory::list_type photo_factories;
-MaRC::MosaicImage::average_type averaging_type;
+MaRC::MosaicImageFactory::average_type averaging_type;
 
 std::unique_ptr<MaRC::PhotoImageParameters> photo_parameters;
 std::unique_ptr<MaRC::ViewingGeometry> viewing_geometry;
@@ -621,7 +621,7 @@ map_entry:
 
             image_factories.clear();
 
-            averaging_type = MaRC::MosaicImage::AVG_WEIGHTED;
+            averaging_type = MaRC::MosaicImageFactory::AVG_WEIGHTED;
 
             /**
              * @deprecated Remove once deprecated plane number support
@@ -1995,11 +1995,11 @@ options_common:
 averaging:
         %empty
         | AVERAGING ':' UNWEIGHTED {
-              averaging_type = MaRC::MosaicImage::AVG_UNWEIGHTED; }
+              averaging_type = MaRC::MosaicImageFactory::AVG_UNWEIGHTED; }
         | AVERAGING ':' WEIGHTED {
-              averaging_type = MaRC::MosaicImage::AVG_WEIGHTED; }
+              averaging_type = MaRC::MosaicImageFactory::AVG_WEIGHTED; }
         | AVERAGING ':' _NONE {
-              averaging_type = MaRC::MosaicImage::AVG_NONE; }
+              averaging_type = MaRC::MosaicImageFactory::AVG_NONE; }
 ;
 
 /* ----------------------- General Subroutines ---------------------------- */

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -16,24 +16,25 @@ AM_CPPFLAGS =               \
 AM_CXXFLAGS = $(CODE_COVERAGE_CXXFLAGS)
 AM_LIBS = $(CODE_COVERAGE_LIBS)
 
-library_tests = \
-  DefaultConfiguration_Test \
-  Math_Test                 \
-  Vector_Test               \
-  Matrix_Test               \
-  Geometry_Test             \
-  OblateSpheroid_Test       \
-  Scale_Offset_Test         \
-  LatitudeImage_Test        \
-  LongitudeImage_Test       \
-  ViewingGeometry_Test      \
-  Mercator_Test             \
-  Orthographic_Test         \
-  PolarStereographic_Test   \
-  extrema_test              \
-  log_test                  \
-  root_find_test            \
-  utility_test              \
+library_tests =                 \
+  DefaultConfiguration_Test     \
+  Math_Test                     \
+  Vector_Test                   \
+  Matrix_Test                   \
+  Geometry_Test                 \
+  OblateSpheroid_Test           \
+  Scale_Offset_Test             \
+  LatitudeImage_Test            \
+  LongitudeImage_Test           \
+  ViewingGeometry_Test          \
+  Mercator_Test                 \
+  Orthographic_Test             \
+  PolarStereographic_Test       \
+  compositing_strategy_test     \
+  extrema_test                  \
+  log_test                      \
+  root_find_test                \
+  utility_test                  \
   validate_test
 
 program_tests = \
@@ -84,6 +85,14 @@ nobase_dist_check_DATA = \
   test_map.marc          \
   test.fits.gz           \
   $(BAD_MARC_FILES)
+
+## -------------------------------------------------------------------
+
+check_LTLIBRARIES = libMaRC_test_images.la
+
+libMaRC_test_images_la_SOURCES = \
+  fixed_value_image.h            \
+  fixed_value_image.cpp
 
 ## -------------------------------------------------------------------
 
@@ -141,6 +150,13 @@ PolarStereographic_Test_SOURCES = PolarStereographic_Test.cpp
 PolarStereographic_Test_LDADD = \
   $(MARC_LIB) \
   $(CODE_COVERAGE_LIBS)
+
+compositing_strategy_test_SOURCES = compositing_strategy_test.cpp
+compositing_strategy_test_LDADD   = \
+  -lMaRC_test_images \
+  $(MARC_LIB) \
+  $(CODE_COVERAGE_LIBS)
+compositing_strategy_test_DEPENDENCIES = libMaRC_test_images.la
 
 extrema_test_SOURCES = extrema_test.cpp
 extrema_test_LDADD   = \

--- a/tests/compositing_strategy_test.cpp
+++ b/tests/compositing_strategy_test.cpp
@@ -1,0 +1,202 @@
+/**
+ * @file compositing_strategy_test.cpp
+ *
+ * Copyright (C) 2021 Ossama Othman
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include "fixed_value_image.h"
+
+#include <marc/first_read.h>
+#include <marc/unweighted_average.h>
+#include <marc/weighted_average.h>
+#include <marc/Mathematics.h>
+
+
+class test_data
+{
+public:
+
+    /**
+     * @brief Constructor.
+     *
+     * @param[in] lat   Latitude in degrees at which data should be
+     *                  composited.
+     * @param[in] lon   Longitude in degrees at which data should be
+     *                  composited.
+     * @param[in] count Expected number of images that contributed to
+     *                  the composite.
+     * @param[in] data  Expected value of the composited data.
+     */
+    test_data(double const lat,
+              double const lon,
+              int count,
+              double data)
+        : point_(lat, lon)
+        , count_(count)
+        , data_(data)
+    {
+    }
+
+    /// Latitude in radians at which data should be composited.
+    auto lat() const { return this->point_.lat(); }
+
+    /// Longitude in radians at which data should be composited.
+    auto lon() const { return this->point_.lon(); }
+
+    /// Expected number of images that contributed to the composite.
+    auto count() const { return this->count_; }
+
+    bool check_data(double data) const
+    {
+        constexpr int ulps = 2;
+
+        return MaRC::almost_equal(data, this->data_, ulps)
+            || (MaRC::almost_zero(data, ulps)
+                && MaRC::almost_zero(this->data_, ulps));
+    }
+
+private:
+
+    /// Lat/lon point in radians at which data should be composited.
+    MaRC::point const point_;
+
+    /// Expected number of images that contributed to the composite.
+    int const count_;
+
+    /// Expected value of the composited data.
+    double const data_;
+
+};
+
+/**
+ * @test Test the MaRC::first_read compositing strategy.
+ */
+bool
+test_first_read(MaRC::compositing_strategy::list_type const & images)
+{
+    test_data const tds[] = {
+        {  5,  5, 0,   0 },  // Not inside an image.
+        { 12, 20, 1, 100 },  // I
+        { 20, 20, 1, 100 },  // I and III
+        { 20, 27, 1, 100 }   // I, II, and III
+    };
+
+    MaRC::first_read cs;
+
+    for (auto const & td : tds) {
+        double data = 0;
+
+        if (cs.composite(images, td.lat(), td.lon(), data) != td.count()
+            || !td.check_data(data))
+            return false;
+    }
+
+    return true;
+}
+
+/**
+ * @test Test the MaRC::unweighted_average compositing strategy.
+ */
+bool
+test_unweighted_average(MaRC::compositing_strategy::list_type const & images)
+{
+    test_data const tds[] = {
+        {  5,  5, 0,   0 },  // Not inside an image.
+        { 12, 20, 1, 100 },  // I
+        { 10, 35, 1, 200 },  // II
+        { 33, 33, 1, 300 },  // III
+        { 12, 27, 2, 150 },  // I and II
+        { 20, 20, 2, 200 },  // I and III
+        { 20, 33, 2, 250 },  // II and III
+        { 20, 27, 3, 200 }   // I, II, and III
+    };
+
+    MaRC::unweighted_average cs;
+
+    for (auto const & td : tds) {
+        double data = 0;
+
+        if (cs.composite(images, td.lat(), td.lon(), data) != td.count()
+            || !td.check_data(data))
+            return false;
+    }
+
+    return true;
+}
+
+/**
+ * @test Test the MaRC::weighted_average compositing strategy.
+ */
+bool
+test_weighted_average(MaRC::compositing_strategy::list_type const & images)
+{
+    test_data const tds[] = {
+        {  5,  5, 0,   0 },  // Not inside an image.
+        { 12, 20, 1, 100 },  // I
+        { 10, 35, 1, 200 },  // II
+        { 33, 33, 1, 300 },  // III
+        { 12, 27, 2, 150 },  // I and II
+        { 21, 21, 2, 180 },  // I and III
+        { 22, 33, 2, 240 },  // II and III
+        { 20, 27, 3, 220 }   // I, II, and III
+    };
+
+    MaRC::weighted_average cs;
+
+    for (auto const & td : tds) {
+        double data = 0;
+
+        if (cs.composite(images, td.lat(), td.lon(), data) != td.count()
+            || !td.check_data(data))
+            return false;
+    }
+
+    return true;
+}
+
+/// The canonical main entry point.
+int main()
+{
+    /*
+                 35 +-----------------+
+                    |                 |
+                    |           III   |
+        30 +--------|--------+        |
+           |        |        |        |
+           |  I     |   +-------------|---+ 25
+           |        |   |    |        |   |
+           |     15 +-----------------+   |
+           |        15  |    |        35  |
+           |            |    |            |
+        10 +------------|----+     II     |
+           10           |    30           |
+                        +-----------------+ 5
+                        25                45
+    */
+    MaRC::point corners[] = {
+        { 10, 10 },  // I
+        {  5, 25 },  // II
+        { 15, 15 }   // III
+    };
+
+    constexpr double edge_length = 20;  // degrees
+
+    std::vector<test_data> td;
+    MaRC::compositing_strategy::list_type images;
+
+    for (std::size_t i = 0; i < std::size(corners); ++i) {
+        double const value = (i + 1) * 100;
+
+        images.emplace_back(
+            std::make_unique<MaRC::fixed_value_image>(corners[i],
+                                                      edge_length,
+                                                      value));
+    }
+
+    return test_first_read(images)
+        && test_unweighted_average(images)
+        && test_weighted_average(images)
+        ? 0 : -1;
+}

--- a/tests/fixed_value_image.cpp
+++ b/tests/fixed_value_image.cpp
@@ -1,0 +1,63 @@
+/**
+ * @file fixed_value_image.cpp
+ *
+ * Copyright (C) 2021  Ossama Othman
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * @author Ossama Othman
+ */
+
+#include "fixed_value_image.h"
+
+#include <marc/Log.h>
+
+
+bool
+MaRC::fixed_value_image::read_data(double lat,
+                                   double lon,
+                                   double & data) const
+{
+    if (lon < this->lower_lon_)
+        lon += C::_2pi;
+    else if (lon > this->upper_lon_)
+        lon -= C::_2pi;
+
+    bool const visible =
+        lat >= this->lower_lat_ && lat <= this->upper_lat_
+        && lon >= this->lower_lon_ && lon <= this->upper_lon_;
+
+    if (visible)
+        data = this->value_;
+
+    return visible;
+}
+
+bool
+MaRC::fixed_value_image::read_data(double lat,
+                                   double lon,
+                                   double & data,
+                                   double & weight,
+                                   bool /* scan */) const
+{
+    bool const visible = this->read_data(lat, lon, data);
+
+    if (visible) {
+        /**
+         * @todo Refactor this duplicate code in both @c read_data()
+         *       methods.
+         */
+        if (lon < this->lower_lon_)
+            lon += C::_2pi;
+        else if (lon > this->upper_lon_)
+            lon -= C::_2pi;
+
+        // Give less weight to pixels close to an edge of the image.
+        weight = std::min(this->upper_lat_ - lat,
+                          std::min(lat - this->lower_lat_,
+                                   std::min(this->upper_lon_ - lon,
+                                            lon - this->lower_lon_)));
+    }
+
+    return visible;
+}

--- a/tests/fixed_value_image.h
+++ b/tests/fixed_value_image.h
@@ -1,0 +1,198 @@
+// -*- C++ -*-
+/**
+ * @file fixed_value_image.h
+ *
+ * Copyright (C) 2021  Ossama Othman
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * @author Ossama Othman
+ */
+
+#ifndef MARC_FIXED_VALUE_IMAGE_H
+#define MARC_FIXED_VALUE_IMAGE_H
+
+#include <marc/SourceImage.h>
+#include <marc/Validate.h>
+#include <marc/Constants.h>
+
+
+namespace MaRC
+{
+    // Latitudes and longitudes passed to constructors in degrees.
+
+    /**
+     * @class point
+     *
+     * @brief A latitude / longitude pair.
+     */
+    class point
+    {
+    public:
+
+        /**
+         * @brief Constructor.
+         *
+         * @param[in] lat Latitude in degrees at which data should be
+         *                composited.
+         * @param[in] lon Longitude in degrees at which data should be
+         *                composited.
+         */
+        point(double lat, double lon)
+            : lat_(validate_latitude(lat))
+            , lon_(validate_longitude(lon))
+        {
+        }
+
+        point(point const &) = default;
+        point & operator=(point const &) = default;
+
+        /// Latitude in radians.
+        double lat() const { return this->lat_; }
+
+        /// Longitude in radians.
+        double lon() const { return this->lon_; }
+
+    private:
+
+        /// Latitude in radians.
+        double const lat_;
+
+        /// Longitude in radians.
+        double const lon_;
+
+    };
+
+    /**
+     * @class fixed_value_image
+     *
+     * @brief Test image that only returns a single value.
+     *
+     * This test image returns a single value within a given "square"
+     * shaped latitude and longitude range.
+     */
+    class fixed_value_image final : public MaRC::SourceImage
+    {
+    public:
+
+        /**
+         * @brief Constructor
+         *
+         * @param[in] lower_corner Lower corner (lat/lon) of test
+         *                         image.
+         * @param[in] edge_length  Length of each side of the image.
+         * @param[in] value        Value found in the "visible"
+         *                         lat/lon range of the image.
+         */
+        fixed_value_image(point const & lower_corner,
+                          double edge_length,
+                          double value)
+            : SourceImage()
+            , lower_lat_(lower_corner.lat())
+            , lower_lon_(lower_corner.lon())
+            , upper_lat_(get_upper_lat(lower_corner.lat(), edge_length))
+            , upper_lon_(get_upper_lon(lower_corner.lon(), edge_length))
+            , value_(value)
+        {
+        }
+
+        ~fixed_value_image() override = default;
+
+        fixed_value_image(fixed_value_image const &) = delete;
+        fixed_value_image & operator=(fixed_value_image const &) = delete;
+        fixed_value_image(fixed_value_image &&) = delete;
+        fixed_value_image & operator=(fixed_value_image &&) = delete;
+
+        /**
+         * @brief Return the value passed to the constructor.
+         *
+         * @see MaRC::SourceImage::read_data().
+         */
+        bool read_data(double lat,
+                       double lon,
+                       double & data) const override;
+
+        /**
+         * @brief Return the value passed to the constructor.
+         *
+         * Return the value and passed to the constructor as well as
+         * a data weight based on proximity of the given @a lat and
+         * @a lon to the image edges.
+         *
+         * @see MaRC::SourceImage::read_data().
+         */
+        bool read_data(double lat,
+                       double lon,
+                       double & data,
+                       double & weight,
+                       bool scan) const override;
+
+    private:
+
+        /// Get upper latitude boundary.
+        double get_upper_lat(double lower_lat, double edge_length) const
+        {
+            // Cannot have latitude great than 90 degrees.  Clamp as
+            // needed.
+            constexpr double max_lat = C::pi_2;
+
+            edge_length *= C::degree; // radians
+
+            double const upper_lat = lower_lat + edge_length;
+
+            return upper_lat > max_lat ? max_lat : upper_lat;
+        }
+
+        /// Get upper longitude boundary.
+        double get_upper_lon(double lower_lon, double edge_length) const
+        {
+            edge_length *= C::degree; // radians
+
+            /*
+              Allow equivalent upper longitude beyond 360 degrees.
+              For example given a lower longitude of 20 degrees, an
+              an upper longitude of 10 degrees, and a longitude X=5
+              degrees, the longitude X is actually in the longitude
+              range [20, 10]:
+
+                lower longitude = 20
+                upper longitude = 10 + 360 = 370
+
+                if (X < lower longitude)
+                   X += 360
+                else if (X > upper longitude)
+                   X -= 360
+
+                X = 5 or 365  (both equivalent since 365 % 360 = 5)
+
+                -X-- 10   20 -----------------
+                          20 -------------------- 370
+
+                20 <= 365 <= 370    in range!
+            */
+            return lower_lon + edge_length;
+        }
+
+    private:
+
+        /// Lower image latitude (radians).
+        double const lower_lat_;
+
+        /// Lower image longitude (radians).
+        double const lower_lon_;
+
+        /// Upper image latitude (radians).
+        double const upper_lat_;
+
+        /// Upper image longitude (radians).
+        double const upper_lon_;
+
+        /// Data value within image bounds.
+        double const value_;
+
+    };
+
+} // End MaRC namespace
+
+
+#endif  /* MARC_FIXED_VALUE_IMAGE_H */


### PR DESCRIPTION
Refactor the `MaRC::MosaicImage` averaging code so that it is fully extensible.  All of MaRC's existing image averaging cases now exist in their own concrete compositing strategy class.  There is no longer a need to hard code the average type within `MaRC::MosaicImage`.

A compositing unit test and accompanying `fixed_value_image` test image was also added.
