### PR TITLE
doc: Do not embed timestamp in MaRC_input manual.

### DIFF
--- a/doc/MaRC_input.texi
+++ b/doc/MaRC_input.texi
@@ -10,12 +10,10 @@
 @comment @setchapternewpage odd
 
 @copying
-This is Edition @value{EDITION},
-last updated @value{UPDATED},
-of @cite{The MaRC Manual},
+This is Edition @value{EDITION} of @cite{The MaRC Manual},
 for @code{MaRC}, version @value{VERSION}.
 
-Copyright @copyright{} 1997-1999, 2003-2004, 2017-2018  Ossama Othman
+Copyright @copyright{} 1997-1999, 2003-2004, 2017-2018, 2022  Ossama Othman
 
 @quotation
 @c SPDX-License-Identifier: GFDL-1.3-or-later
@@ -32,7 +30,6 @@ Free Documentation License".
 @title MaRC Input Files
 @subtitle Creation of Input and User Configuration Files
 @subtitle Edition @value{EDITION}
-@subtitle @value{UPDATED-MONTH}
 @author Ossama Othman
 
 @c  The following two commands


### PR DESCRIPTION
To better support reproducible builds, do not embed a timestamp in the
MaRC_input manual.

See: https://reproducible-builds.org/docs/timestamps/