### PR TITLE
Leverage C++17 features.

### DIFF
--- a/lib/marc/BilinearInterpolation.cpp
+++ b/lib/marc/BilinearInterpolation.cpp
@@ -87,5 +87,5 @@ MaRC::BilinearInterpolation::interpolate(double const * data,
         return true;
     }
 
-  return false;
+    return false;
 }

--- a/lib/marc/Mathematics.h
+++ b/lib/marc/Mathematics.h
@@ -2,7 +2,7 @@
 /**
  * @file Mathematics.h
  *
- * Copyright (C) 2017  Ossama Othman
+ * Copyright (C) 2017, 2022  Ossama Othman
  *
  * SPDX-License-Identifier: LGPL-2.1-or-later
  *
@@ -24,50 +24,6 @@
 
 namespace MaRC
 {
-#if __cplusplus < 201703L
-    /**
-     * @brief Distance of (x,y,z) from the origin.
-     *
-     * Compute the distance of the point in space (@a x, @a y, @a z)
-     * from the origin (0, 0, 0).  This function is implemented in
-     * terms of the two-parameter @c std::hypot() to leverage its
-     * ability to perform the operation without floating point
-     * underflow or overflow, as well as its excellent floating point
-     * error characteristics.
-     *
-     * @param[in] x,y,z Coordinate in space.
-     *
-     * @return Distance from the origin to the point in space (@a x,
-     *         @a y, @a z), i.e. the equivalent of the square root of
-     *         the sum of the squares of each coordinate
-     *         \f$\sqrt{x^2+y^2+z^2}\f$.
-     *
-     * @deprecated This implementation of the three-parameter
-     *             @c std::hypot() will be dropped once we start
-     *             using C++17 features in %MaRC.
-     */
-    template <typename T>
-    auto hypot(T x, T y, T z)
-    {
-        /*
-          Implement the missing three parameter std::hypot() function
-          by nesting two std::hypot() calls.  This works since:
-          Given:
-              std::hypot(x,y)   = sqrt(x*x + y*y)
-          and:
-              std::hypot(x,y,z) = sqrt(x*x + y*y + z*z)
-          We have:
-              std::hypot(std::hypot(x, y), z)
-                  = sqrt((sqrt(x*x + y*y) * sqrt(x*x + y*y)) + z*z)
-                  = sqrt(x*x + y*y + z*z) =
-                  = std::hypot(x, y, z)
-        */
-        return std::hypot(std::hypot(x, y), z);
-    }
-#endif  // __cplusplus < 201703L
-
-    using std::hypot;
-
     /**
      * @brief Compare two floating point numbers for equality.
      *

--- a/lib/marc/Matrix.h
+++ b/lib/marc/Matrix.h
@@ -4,7 +4,7 @@
  *
  * %MaRC matrix class and operations.
  *
- * Copyright (C) 2004, 2017-2018, 2021  Ossama Othman
+ * Copyright (C) 2004, 2017-2018, 2021-2022,  Ossama Othman
  *
  * SPDX-License-Identifier: LGPL-2.1-or-later
  *
@@ -128,7 +128,7 @@ namespace MaRC
          * @return Reference to element at given @c Matrix @a row and
          *         @a column.
          */
-        inline reference operator()(std::size_t row, std::size_t column)
+        constexpr reference operator()(std::size_t row, std::size_t column)
         {
             return this->matrix_[row][column];
         }
@@ -144,8 +144,8 @@ namespace MaRC
          * @return Reference to @c const element at given @c Matrix
          *         @a row and @a column.
          */
-        inline const_reference operator()(std::size_t row,
-                                          std::size_t column) const
+        constexpr const_reference operator()(std::size_t row,
+                                             std::size_t column) const
         {
             return this->matrix_[row][column];
         }
@@ -161,7 +161,7 @@ namespace MaRC
          * @return Reference to element at given @c Matrix @a row and
          *         @a column.
          */
-        inline reference at(std::size_t row, std::size_t column)
+        constexpr reference at(std::size_t row, std::size_t column)
         {
             if (row >= M || column >= N) {
                 throw std::out_of_range("Out of range matrix index "
@@ -182,8 +182,8 @@ namespace MaRC
          * @return Reference to @c const element at given @c Matrix
          *         @a row and @a column.
          */
-        inline const_reference at(std::size_t row,
-                                  std::size_t column) const
+        constexpr const_reference at(std::size_t row,
+                                     std::size_t column) const
         {
             if (row >= M || column >= N) {
                 throw std::out_of_range("Out of range matrix index "
@@ -332,7 +332,7 @@ namespace MaRC
      * @relates MaRC::Matrix
      */
     template <typename T, std::size_t M, std::size_t N>
-    Matrix<T, N, M> transpose(Matrix<T, M, N> const & m)
+    constexpr Matrix<T, N, M> transpose(Matrix<T, M, N> const & m)
     {
         Matrix<T, N, M> t;
 

--- a/lib/marc/Vector.h
+++ b/lib/marc/Vector.h
@@ -4,7 +4,7 @@
  *
  * %MaRC mathematical vector class and operations.
  *
- * Copyright (C) 2004, 2017-2018, 2021  Ossama Othman
+ * Copyright (C) 2004, 2017-2018, 2021-2022,  Ossama Othman
  *
  * SPDX-License-Identifier: LGPL-2.1-or-later
  *
@@ -126,7 +126,7 @@ namespace MaRC
          *
          * @return Reference to element at given @c Vector @a row.
          */
-        inline reference operator[](std::size_t row)
+        constexpr reference operator[](std::size_t row)
         {
             return this->vector_[row];
         }
@@ -141,7 +141,7 @@ namespace MaRC
          * @return Reference to @c const element at given @c Vector
          *         @a row.
          */
-        inline const_reference operator[] (std::size_t row) const
+        constexpr const_reference operator[] (std::size_t row) const
         {
             return this->vector_[row];
         }
@@ -155,7 +155,7 @@ namespace MaRC
          *
          * @return Reference to element at given @c Vector @a row.
          */
-        inline reference at(std::size_t row)
+        constexpr reference at(std::size_t row)
         {
             if (row >= M)
                 throw std::out_of_range("Out of range vector index");
@@ -173,7 +173,7 @@ namespace MaRC
          * @return Reference to @c const element at given @c Vector
          *         @a row.
          */
-        inline const_reference at(std::size_t row) const
+        constexpr const_reference at(std::size_t row) const
         {
             if (row >= M)
                 throw std::out_of_range ("Out of range vector index");
@@ -190,7 +190,7 @@ namespace MaRC
          *       iteration of the vector.  It is not intended for
          *       general use.
          */
-        inline iterator begin()
+        constexpr iterator begin()
         {
             return &this->vector_[0];
         }
@@ -206,7 +206,7 @@ namespace MaRC
          *       iteration of the vector.  It is not intended for
          *       general use.
          */
-        inline const_iterator begin() const
+        constexpr const_iterator begin() const
         {
             return &this->vector_[0];
         }
@@ -220,7 +220,7 @@ namespace MaRC
          *       iteration of the vector.  It is not intended for
          *       general use.
          */
-        inline iterator end()
+        constexpr iterator end()
         {
             return &this->vector_[0] + M;
         }
@@ -234,7 +234,7 @@ namespace MaRC
          *       iteration of the vector.  It is not intended for
          *       general use.
          */
-        inline const_iterator end() const
+        constexpr const_iterator end() const
         {
             return &this->vector_[0] + M;
         }
@@ -344,8 +344,8 @@ namespace MaRC
      * @relates MaRC::Vector
      */
     template <typename T, std::size_t M>
-    auto dot_product(Vector<T, M> const & a,
-                     Vector<T, M> const & b)
+    constexpr auto dot_product(Vector<T, M> const & a,
+                               Vector<T, M> const & b)
     {
         return std::inner_product(std::cbegin(a),
                                   std::cend(a),

--- a/lib/marc/ViewingGeometry.cpp
+++ b/lib/marc/ViewingGeometry.cpp
@@ -711,7 +711,7 @@ MaRC::ViewingGeometry::set_km_per_pixel()
 
     this->km_per_pixel_ =
         this->range_ /
-        MaRC::hypot(this->OA_s_ - this->sample_center_,
+        std::hypot(this->OA_s_ - this->sample_center_,
                     this->focal_length_pixels_,
                     this->OA_l_ - this->line_center_);
 }

--- a/lib/marc/details/vector.h
+++ b/lib/marc/details/vector.h
@@ -14,7 +14,7 @@
 #ifndef MARC_DETAILS_VECTOR_H
 #define MARC_DETAILS_VECTOR_H
 
-#include "marc/Mathematics.h"
+#include <cmath>
 
 
 namespace MaRC
@@ -67,9 +67,9 @@ namespace MaRC
          * @return Magnitude of vector @a v.
          */
         template <typename T>
-        constexpr auto magnitude(T const (&v)[3])
+        auto magnitude(T const (&v)[3])
         {
-            return MaRC::hypot(v[0], v[1], v[2]);
+            return std::hypot(v[0], v[1], v[2]);
         }
 
         /**
@@ -84,7 +84,7 @@ namespace MaRC
          * @return Magnitude of vector @a v.
          */
         template <typename T>
-        constexpr auto magnitude(T const (&v)[2])
+        auto magnitude(T const (&v)[2])
         {
             return std::hypot(v[0], v[1]);
         }

--- a/lib/marc/extrema.h
+++ b/lib/marc/extrema.h
@@ -203,7 +203,7 @@ namespace MaRC
          */
         void swap(extrema & other) noexcept(
             std::is_nothrow_move_constructible<T>::value
-            /* && std::is_nothrow_swappable<T>::value */)
+            && std::is_nothrow_swappable<T>::value)
         {
             using std::swap;
 

--- a/lib/marc/utility.h
+++ b/lib/marc/utility.h
@@ -4,7 +4,7 @@
  *
  * %MaRC utility functions.
  *
- * Copyright (C) 2017, 2018  Ossama Othman
+ * Copyright (C) 2017, 2018, 2022  Ossama Othman
  *
  * SPDX-License-Identifier: LGPL-2.1-or-later
  *
@@ -21,76 +21,6 @@
 
 namespace MaRC
 {
-#if __cplusplus < 201703L
-    /**
-     * @brief Get pointer to memory containing the container
-     *
-     * @deprecated This is an implementation of the C++17
-     *             @c std::data() function.  It will be removed when
-     *             %MaRC requires C++17.
-     */
-    template <class C>
-    constexpr auto data(C & c) -> decltype(c.data())
-    {
-        return c.data();
-    }
-
-    /**
-     * @brief Get pointer to memory containing the container
-     *
-     * @deprecated This is an implementation of the C++17
-     *             @c std::data() function.  It will be removed when
-     *             %MaRC requires C++17.
-     */
-    template <class C>
-    constexpr auto data(C const & c) -> decltype(c.data())
-    {
-        return c.data();
-    }
-
-    /**
-     * @brief Get pointer to memory containing the array.
-     *
-     * @deprecated This is an implementation of the C++17
-     *             @c std::data() function.  It will be removed when
-     *             %MaRC requires C++17.
-     */
-    template <typename T, std::size_t N>
-    constexpr T * data(T (&array)[N]) noexcept
-    {
-        return array;
-    }
-
-    /**
-     * @brief Get the size of a container.
-     *
-     * @deprecated This is an implementation of the C++17
-     *             @c std::size() function.  It will be removed when
-     *             %MaRC requires C++17.
-     */
-    template <class C>
-    constexpr auto size(C const & c) -> decltype(c.size())
-    {
-        return c.size();
-    }
-
-    /**
-     * @brief Get the length of an array.
-     *
-     * @deprecated This is an implementation of the C++17
-     *             @c std::size() function.  It will be removed when
-     *             %MaRC requires C++17.
-     */
-    template <typename T, std::size_t N>
-    constexpr std::size_t size(T const (& /* array */)[N]) noexcept
-    {
-        return N;
-    }
-#else
-    using std::data;
-    using std::size;
-#endif  // __cplusplus < 201703L
-
     /**
      * @brief Invert image samples (columns).
      *
@@ -112,7 +42,7 @@ namespace MaRC
                    std::size_t samples,
                    std::size_t lines)
     {
-        if (MaRC::size(image) != samples * lines)
+        if (std::size(image) != samples * lines)
             throw std::invalid_argument("Image size does not match "
                                         "number of samples and lines.");
 
@@ -145,7 +75,7 @@ namespace MaRC
                  std::size_t samples,
                  std::size_t lines)
     {
-        if (MaRC::size(image) != samples * lines)
+        if (std::size(image) != samples * lines)
             throw std::invalid_argument("Image size does not match "
                                         "number of samples and lines.");
 

--- a/src/FITS_image_t.cpp
+++ b/src/FITS_image_t.cpp
@@ -18,6 +18,7 @@
 
 #include <fitsio.h>
 
+#include <array>  // For std::size().
 #include <cmath>
 
 
@@ -94,11 +95,11 @@ MaRC::FITS::image::write(T const & img)
         MaRC::error("FITS image array is already fully written.");
 
         return false;
-    } else if(static_cast<LONGLONG>(MaRC::size(img))
+    } else if(static_cast<LONGLONG>(std::size(img))
               != this->nelements_) {
         MaRC::error("FITS image and data array sizes, "
                     "{} and {}, do not match.",
-                    this->nelements_, MaRC::size(img));
+                    this->nelements_, std::size(img));
 
         return false;
     }
@@ -113,7 +114,7 @@ MaRC::FITS::image::write(T const & img)
          Plane 4: ... etc ...
     */
 
-    auto data = MaRC::data(img);
+    auto data = std::data(img);
 
     /*
       CFITSIO expects the data to passed as a non-const pointer to

--- a/src/marc.cpp
+++ b/src/marc.cpp
@@ -17,9 +17,9 @@
 
 #include <marc/config.h>
 #include <marc/Log.h>
-#include <marc/utility.h>
 
 #include <string>
+#include <array>  // For std::size().
 #include <cstdio>
 #include <cerrno>
 #include <cstdlib>
@@ -104,7 +104,7 @@ namespace MaRC
             char buf[BUFLEN] = {};
 
             char const * const error =
-                MaRC::strerror(errno, buf, MaRC::size(buf));
+                MaRC::strerror(errno, buf, std::size(buf));
 
             MaRC::debug("Unable to open input file '{}': {}",
                         filename,

--- a/src/parse.yy
+++ b/src/parse.yy
@@ -51,6 +51,7 @@
 #include <stdexcept>
 #include <limits>
 #include <memory>
+#include <array>  // For std::size().
 #include <cstring>
 #include <cerrno>
 #include <cmath>
@@ -295,7 +296,7 @@ namespace
             char buf[BUFLEN] = {};
 
             char const * const err =
-                MaRC::strerror(errno, buf, MaRC::size(buf));
+                MaRC::strerror(errno, buf, std::size(buf));
 
             errno = 0;
 

--- a/src/strerror.h
+++ b/src/strerror.h
@@ -1,7 +1,7 @@
 /**
  * @file strerror.h
  *
- * Copyright (C) 2018  Ossama Othman
+ * Copyright (C) 2018, 2022  Ossama Othman
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  *
@@ -12,17 +12,6 @@
 #define MARC_STRERROR_H
 
 #include <cstring>
-
-// Check if we can use the C++17 [[maybe_unused]] attribute.
-// Otherwise fall back on the equivalent attribute in a
-// compiler-specific attribute namespace if one exists.
-#if __cplusplus >= 201703L
-# define MARC_UNUSED [[maybe_unused]]
-#elif defined(__GNUG__)
-# define MARC_UNUSED [[gnu::unused]]
-#else
-# define MARC_UNUSED
-#endif  // __cplusplus >= 201703L
 
 
 namespace MaRC
@@ -40,7 +29,7 @@ namespace MaRC
          *
          * @note Not part of the %MaRC API.
          */
-        MARC_UNUSED
+        [[maybe_unused]]
         inline char const * strerror_helper(int /* result */,
                                             char const * buf)
         {
@@ -66,7 +55,7 @@ namespace MaRC
          *
          * @note Not part of the %MaRC API.
          */
-        MARC_UNUSED
+        [[maybe_unused]]
         inline char const * strerror_helper(char const * result,
                                             char const * /* buf */)
         {

--- a/tests/Mercator_Test.cpp
+++ b/tests/Mercator_Test.cpp
@@ -1,7 +1,7 @@
 /**
  * @file Mercator_Test.cpp
  *
- * Copyright (C) 2018 Ossama Othman
+ * Copyright (C) 2018, 2022  Ossama Othman
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
@@ -11,6 +11,7 @@
 #include <marc/LatitudeImage.h>
 #include <marc/Constants.h>
 #include <marc/DefaultConfiguration.h>
+#include <marc/Mathematics.h>
 #include <marc/scale_and_offset.h>
 
 #include <memory>
@@ -112,8 +113,8 @@ bool test_make_map()
         return false;
 
     /*
-      Pick a random sample along the center line (equator) in the
-      projection.  There is no need for a non-deterministically
+      Pick a pseudo-random sample along the center line (equator) in
+      the projection.  There is no need for a non-deterministically
       generated seed value for the purposes of this test.
     */
     std::mt19937 generator(std::time(nullptr));

--- a/tests/OblateSpheroid_Test.cpp
+++ b/tests/OblateSpheroid_Test.cpp
@@ -135,7 +135,7 @@ bool test_centric_radius()
         &&  MaRC::almost_equal(c, o->centric_radius(south_pole), ulps)
         && !MaRC::almost_equal(c, o->centric_radius(equator),    ulps)
 
-        && MaRC::almost_equal(r, MaRC::hypot(x, y, z), ulps);
+        && MaRC::almost_equal(r, std::hypot(x, y, z), ulps);
 }
 
 /**

--- a/tests/Orthographic_Test.cpp
+++ b/tests/Orthographic_Test.cpp
@@ -9,6 +9,7 @@
 #include <marc/Orthographic.h>
 #include <marc/OblateSpheroid.h>
 #include <marc/LatitudeImage.h>
+#include <marc/Mathematics.h>
 #include <marc/Constants.h>
 #include <marc/DefaultConfiguration.h>
 #include <marc/scale_and_offset.h>

--- a/tests/PolarStereographic_Test.cpp
+++ b/tests/PolarStereographic_Test.cpp
@@ -9,6 +9,7 @@
 #include <marc/PolarStereographic.h>
 #include <marc/OblateSpheroid.h>
 #include <marc/LatitudeImage.h>
+#include <marc/Mathematics.h>
 #include <marc/Constants.h>
 #include <marc/DefaultConfiguration.h>
 #include <marc/scale_and_offset.h>

--- a/tests/Vector_Test.cpp
+++ b/tests/Vector_Test.cpp
@@ -1,13 +1,13 @@
 /**
  * @file Vector_Test.cpp
  *
- * Copyright (C) 2017 Ossama Othman
+ * Copyright (C) 2017, 2022, Ossama Othman
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
 #include <marc/Vector.h>
-
+#include <marc/Mathematics.h>   // For MaRC::almost_equal()
 
 namespace
 {

--- a/tests/ViewingGeometry_Test.cpp
+++ b/tests/ViewingGeometry_Test.cpp
@@ -1,7 +1,7 @@
 /**
- * @file Vector_Test.cpp
+ * @file ViewingGeometry_Test.cpp
  *
- * Copyright (C) 2017 Ossama Othman
+ * Copyright (C) 2017, 2022  Ossama Othman
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
@@ -9,6 +9,7 @@
 #include <marc/ViewingGeometry.h>
 #include <marc/OblateSpheroid.h>
 #include <marc/Constants.h>
+#include <marc/Mathematics.h>
 
 
 namespace
@@ -132,8 +133,8 @@ bool test_lat_lon_center()
 
     /**
      * @todo Verify that viewing geometry calculations are correct
-     *       when using specifying the latitude and longitude at the
-     *       center of the image.
+     *       when specifying the latitude and longitude at the center
+     *       of the image.
      */
 
     return true;


### PR DESCRIPTION
Remove MaRC implementations of C++17 features such as `MaRC::hypot()`, `MaRC::size()` and `MaRC::data()`. 

Enable use of some C++17 features such as `constexpr` methods and `std::is_nothrow_swappable<>`.