### PR TITLE
lib: Disallow copying and moving as appropriate.

### DIFF
--- a/lib/marc/first_read.h
+++ b/lib/marc/first_read.h
@@ -31,6 +31,9 @@ namespace MaRC
     {
     public:
 
+        /// Constructor.
+        first_read() = default;
+
         // Disallow copying.
         first_read(first_read const &) = delete;
         first_read & operator=(first_read const &) = delete;

--- a/lib/marc/first_read.h
+++ b/lib/marc/first_read.h
@@ -2,7 +2,7 @@
 /**
  * @file first_read.h
  *
- * Copyright (C) 2021  Ossama Othman
+ * Copyright (C) 2021, 2022  Ossama Othman
  *
  * SPDX-License-Identifier: LGPL-2.1-or-later
  *
@@ -30,6 +30,14 @@ namespace MaRC
     class MARC_API first_read final : public compositing_strategy
     {
     public:
+
+        // Disallow copying.
+        first_read(first_read const &) = delete;
+        first_read & operator=(first_read const &) = delete;
+
+        // Disallow moving.
+        first_read(first_read &&) = delete;
+        first_read & operator=(first_read &&) = delete;
 
         /// Destructor.
         ~first_read() override = default;

--- a/lib/marc/unweighted_average.h
+++ b/lib/marc/unweighted_average.h
@@ -30,6 +30,9 @@ namespace MaRC
     {
     public:
 
+        /// Constructor.
+        unweighted_average() = default;
+
         // Disallow copying.
         unweighted_average(unweighted_average const &) = delete;
         unweighted_average & operator=(

--- a/lib/marc/unweighted_average.h
+++ b/lib/marc/unweighted_average.h
@@ -2,7 +2,7 @@
 /**
  * @file unweighted_average.h
  *
- * Copyright (C) 2021  Ossama Othman
+ * Copyright (C) 2021, 2022  Ossama Othman
  *
  * SPDX-License-Identifier: LGPL-2.1-or-later
  *
@@ -29,6 +29,15 @@ namespace MaRC
     class MARC_API unweighted_average final : public compositing_strategy
     {
     public:
+
+        // Disallow copying.
+        unweighted_average(unweighted_average const &) = delete;
+        unweighted_average & operator=(
+            unweighted_average const &) = delete;
+
+        // Disallow moving.
+        unweighted_average(unweighted_average &&) = delete;
+        unweighted_average & operator=(unweighted_average &&) = delete;
 
         /// Destructor.
         ~unweighted_average() override = default;

--- a/lib/marc/weighted_average.h
+++ b/lib/marc/weighted_average.h
@@ -30,6 +30,9 @@ namespace MaRC
     {
     public:
 
+        /// Constructor.
+        weighted_average() = default;
+
         // Disallow copying.
         weighted_average(weighted_average const &) = delete;
         weighted_average & operator=(weighted_average const &) = delete;

--- a/lib/marc/weighted_average.h
+++ b/lib/marc/weighted_average.h
@@ -2,7 +2,7 @@
 /**
  * @file weighted_average.h
  *
- * Copyright (C) 2021  Ossama Othman
+ * Copyright (C) 2021, 2022  Ossama Othman
  *
  * SPDX-License-Identifier: LGPL-2.1-or-later
  *
@@ -29,6 +29,14 @@ namespace MaRC
     class MARC_API weighted_average final : public compositing_strategy
     {
     public:
+
+        // Disallow copying.
+        weighted_average(weighted_average const &) = delete;
+        weighted_average & operator=(weighted_average const &) = delete;
+
+        // Disallow moving.
+        weighted_average(weighted_average &&) = delete;
+        weighted_average & operator=(weighted_average &&) = delete;
 
         /// Destructor.
         ~weighted_average() override = default;


### PR DESCRIPTION
Disallow copy and move constructors and assignment operators in the
concrete compositing strategies.  They aren't needed.