### PR TITLE
tests: Support 'check-valgrind' make target.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -55,6 +55,11 @@ MARC_CLANG_TIDY
 
 AX_CODE_COVERAGE
 
+AX_VALGRIND_DFLT([helgrind], [off])
+AX_VALGRIND_DFLT([drd],      [off])
+AX_VALGRIND_DFLT([sgcheck],  [off])
+AX_VALGRIND_CHECK
+
 dnl Check for pkg-config
 PKG_PROG_PKG_CONFIG
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -239,3 +239,7 @@ clean-local: code-coverage-clean
 #     LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib make installcheck
 installcheck-local:
 	$(DESTDIR)$(bindir)/marc$(EXEEXT) $(srcdir)/test_map.marc > /dev/null
+
+@VALGRIND_CHECK_RULES@
+#VALGRIND_SUPPRESSIONS_FILES = marc.supp
+#EXTRA_DIST = marc.supp


### PR DESCRIPTION
Leverage the AX_VALGRIND_CHECK Autoconf Archive macro to add a new
'check-valgrind' target to the MaRC Makefiles.  This allows each of
the MaRC unit tests to be executed under Valgrind by running `make
check-valgrind' to simplify memory related problem detection.