### PR TITLE
lib: Simplify GLL summation mode detection.

### DIFF
--- a/lib/marc/GLLGeometricCorrection.cpp
+++ b/lib/marc/GLLGeometricCorrection.cpp
@@ -1,7 +1,7 @@
 /**
  * @file GLLGeometricCorrection.cpp
  *
- * Copyright (C) 2003-2004, 2017  Ossama Othman
+ * Copyright (C) 2003-2004, 2017, 2022  Ossama Othman
  *
  * SPDX-License-Identifier: LGPL-2.1-or-later
  *
@@ -25,20 +25,15 @@ namespace MaRC
         static constexpr double DISTORTION = 0.00000000658;
 
         /// Default optical axis line.
-        static constexpr double OA_LINE = 400;
+        static constexpr std::size_t OA_LINE = 400;
 
         /// Default optical axis sample.
-        static constexpr double OA_SAMPLE = 400;
+        static constexpr std::size_t OA_SAMPLE = 400;
     }
 }
 
-
-// Base summation mode detection on (samples > 1.1 * OA_SAMPLE)
-// instead of (samples > OA_SAMPLE) to avoid potential inexact
-// comparisons of two equal values e.g. (400.0 > 400.0000001).
 MaRC::GLLGeometricCorrection::GLLGeometricCorrection(std::size_t samples)
-    : summation_mode_(samples > 1.1 * MaRC::GLL::OA_SAMPLE
-                      ? false : true)
+    : summation_mode_(samples <= MaRC::GLL::OA_SAMPLE)
 {
 }
 

--- a/lib/marc/GLLGeometricCorrection.h
+++ b/lib/marc/GLLGeometricCorrection.h
@@ -4,7 +4,7 @@
 /**
  * @file GLLGeometricCorrection.h
  *
- * Copyright (C) 1999, 2003-2004, 2017  Ossama Othman
+ * Copyright (C) 1999, 2003-2004, 2017, 2022  Ossama Othman
  *
  * SPDX-License-Identifier: LGPL-2.1-or-later
  *
@@ -22,12 +22,6 @@
 #include <cstddef>
 
 
-//   // Kludge to "automatically" detect summation mode images
-//   if (Samples_ > OA_SAMP)
-//     this->summation_mode_ = 1; // Full frame
-//   else
-//     this->summation_mode_ = 2; // Summation mode frame
-
 namespace MaRC
 {
     /**
@@ -35,20 +29,26 @@ namespace MaRC
      *
      * @brief Galileo Spacecraft lens aberration correction strategy.
      *
-     * Galileo specific concrete geometric correction strategy.
+     * Galileo specific geometric correction strategy.
      */
     class MARC_API GLLGeometricCorrection final
         : public GeometricCorrection
     {
     public:
 
-        /// Constructor
         /**
+         * @brief Constructor
+         *
          * @param[in] samples Number of samples in the PhotoImage.
          *                    Only used to determine whether summation
-         *                    mode should be enabled.
+         *                    mode should be enabled.  Full frame
+         *                    images are 800x800. Summation mode
+         *                    images are 400x400.
          */
         GLLGeometricCorrection(std::size_t samples);
+
+        /// Destructor.
+        ~GLLGeometricCorrection() override = default;
 
         /**
          * @name GeometricCorrection Methods
@@ -56,12 +56,12 @@ namespace MaRC
          * Virtual methods required by the GeometricCorrection abstract
          * base class.
          */
-        //@{
+        ///@{
         void image_to_object(double & line,
                              double & sample) const override;
         void object_to_image(double & line,
                              double & sample) const override;
-        //@}
+        ///@}
 
         /// Return current summation mode
         bool summation_mode() const { return this->summation_mode_; }


### PR DESCRIPTION
Change GLL optical axis type from `double` to `size_t` to simplify the summation mode detection logic by removing the need to be concerned about comparisons of numbers that cannot be exactly represented as floating point values.
